### PR TITLE
fix(batchrouter): raise snowpipe stuck-pipeline alert only for actionable causes

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -59,6 +59,7 @@ func New(
 		now:                 timeutil.Now,
 		channelCache:        sync.Map{},
 		polledImportInfoMap: make(map[string]*importInfo),
+		committedOffsets:    make(map[string]*committedOffsetProgress),
 	}
 
 	m.config.client.url = conf.GetStringVar("http://localhost:9078", "SnowpipeStreaming.Client.URL")
@@ -705,6 +706,13 @@ func (m *Manager) Poll(_ context.Context, pollInput common.AsyncPoll) common.Pol
 		}
 	}
 
+	// Channels are reused across batches, so offset samples left behind by a batch that never reached
+	// its terminal poll must not be read as a stall for the next one. A zero polling start time is the
+	// existing signal that a new batch is starting.
+	if m.pollingStartTime.IsZero() {
+		m.committedOffsets = make(map[string]*committedOffsetProgress)
+	}
+
 	inProgressInfos := m.provideInProgressImportInfos(ctx, importInfos)
 	if len(inProgressInfos) > 0 {
 		m.stats.pollingInProgress.Increment()
@@ -723,14 +731,12 @@ func (m *Manager) Poll(_ context.Context, pollInput common.AsyncPoll) common.Pol
 			return common.PollStatusResponse{InProgress: true}
 		}
 
-		// The bulk-status endpoint can silently report a server-side broken channel as valid=true
-		// (snowflake-ingest-java#1154), so a channel that looks in-progress here may actually be invalid.
-		// Re-check each in-progress channel via the single-channel status endpoint, which surfaces the
-		// failure. Channels confirmed invalid are recovered through the normal failed-import path without
-		// raising the stuck-pipeline alert; genuinely stuck (or inconclusive) channels keep the alert.
+		// A channel still in progress at the threshold is recovered the same way whatever the cause,
+		// but only a cause we may have to act on ourselves raises the stuck-pipeline alert.
 		var stuckInfos []*importInfo
 		for _, info := range inProgressInfos {
-			if invalid := m.isChannelInvalidViaSingleStatus(ctx, info.ChannelID); invalid {
+			switch m.classifyStuckChannel(ctx, info.ChannelID) {
+			case causeChannelInvalid:
 				m.logger.Warnn("Channel reported invalid at stuck threshold; recovering without stuck-pipeline alert",
 					logger.NewStringField("channelId", info.ChannelID),
 					logger.NewStringField("table", info.Table),
@@ -740,22 +746,37 @@ func (m *Manager) Poll(_ context.Context, pollInput common.AsyncPoll) common.Pol
 				info.Failed = true
 				info.Reason = "channel reported invalid by per-channel status check after threshold"
 				m.polledImportInfoMap[info.ChannelID] = info
-				continue
+			case causeNotPersisting:
+				m.logger.Warnn("Snowpipe stopped persisting rows for channel; recovering without stuck-pipeline alert",
+					logger.NewStringField("channelId", info.ChannelID),
+					logger.NewStringField("table", info.Table),
+					logger.NewStringField("expectedOffset", info.Offset),
+					logger.NewDurationField("duration", duration),
+					logger.NewDurationField("threshold", threshold),
+				)
+				info.Failed = true
+				info.Reason = "channel valid but its committed offset did not advance before threshold"
+				m.polledImportInfoMap[info.ChannelID] = info
+			default:
+				stuckInfos = append(stuckInfos, info)
 			}
-			stuckInfos = append(stuckInfos, info)
 		}
 
 		if len(stuckInfos) > 0 {
-			m.logger.Warnn("Stuck snowpipe pipeline detected",
-				logger.NewDurationField("duration", duration),
-				logger.NewDurationField("threshold", threshold),
-				logger.NewStringField("importID", pollInput.ImportId),
-			)
 			for _, info := range stuckInfos {
 				info.Failed = true
 				info.Reason = fmt.Sprintf("events still in progress after threshold: %s > %s", duration, threshold)
 				m.polledImportInfoMap[info.ChannelID] = info
 			}
+			// Only the stuck channels are logged: logging the whole import ID makes every channel in
+			// the batch look stuck, including the ones that flushed successfully.
+			m.logger.Warnn("Stuck snowpipe pipeline detected",
+				logger.NewDurationField("duration", duration),
+				logger.NewDurationField("threshold", threshold),
+				logger.NewIntField("stuckChannels", int64(len(stuckInfos))),
+				logger.NewIntField("channelsInBatch", int64(len(importInfos))),
+				logger.NewStringField("stuckImports", stringify.Any(stuckInfos)),
+			)
 		}
 	}
 
@@ -770,6 +791,7 @@ func (m *Manager) Poll(_ context.Context, pollInput common.AsyncPoll) common.Pol
 	// Reset batch polling start time since all imports completed
 	m.pollingStartTime = time.Time{}
 	m.polledImportInfoMap = make(map[string]*importInfo)
+	m.committedOffsets = make(map[string]*committedOffsetProgress)
 
 	return m.buildPollStatusResponse(updatedImportInfos, failedImports)
 }
@@ -845,20 +867,65 @@ func (m *Manager) getBulkStatusForChannel(ctx context.Context, channelID string)
 	return statusRes, nil
 }
 
-// isChannelInvalidViaSingleStatus re-checks a single channel through the per-channel status endpoint,
-// which (unlike bulk status) surfaces server-side channel failures. It returns true only when the
-// channel is positively confirmed invalid. On an inconclusive result (request error) it returns false
-// so the caller falls back to stuck-pipeline handling (fail-safe: never suppress a genuine alert).
-func (m *Manager) isChannelInvalidViaSingleStatus(ctx context.Context, channelID string) bool {
+// classifyStuckChannel determines why a channel was still in progress once the stuck threshold was
+// crossed, so that only causes which may need a fix on our side raise the stuck-pipeline alert.
+//
+// The bulk-status endpoint can silently report a server-side broken channel as valid=true
+// (snowflake-ingest-java#1154), so the channel is re-checked through the single-channel status
+// endpoint, which surfaces the failure.
+//
+// A channel that is valid and already holds every row we sent, but whose committed offset never moved
+// while we polled, is one Snowpipe accepted rows for and then stopped persisting
+// (snowflake-ingest-java#351). That is a Snowflake-side fault the manager recovers from on its own,
+// so it is reported separately instead of as a stuck pipeline.
+//
+// Anything else - including an inconclusive status check - is reported as stuck, so a pipeline we
+// cannot explain is never silently suppressed.
+func (m *Manager) classifyStuckChannel(ctx context.Context, channelID string) stuckChannelCause {
 	statusRes, err := m.api.GetStatus(ctx, channelID)
 	if err != nil {
 		m.logger.Warnn("Failed to get single-channel status at stuck threshold; treating as stuck",
 			logger.NewStringField("channelId", channelID),
 			obskit.Error(err),
 		)
-		return false
+		return causeStuck
 	}
-	return !statusRes.Valid || !statusRes.Success
+	if !statusRes.Valid || !statusRes.Success {
+		return causeChannelInvalid
+	}
+	if m.hasStalledCommittedOffset(channelID) {
+		return causeNotPersisting
+	}
+	return causeStuck
+}
+
+// recordCommittedOffset samples the latest committed offset of an in-progress channel so that a
+// channel Snowpipe stopped persisting can be told apart from one that is merely flushing slowly.
+// An offset that cannot be parsed is skipped: fewer samples only make the caller more conservative.
+func (m *Manager) recordCommittedOffset(channelID, offset string) {
+	committedOffset, err := convertToInt(offset)
+	if err != nil {
+		return
+	}
+
+	progress, ok := m.committedOffsets[channelID]
+	if !ok {
+		m.committedOffsets[channelID] = &committedOffsetProgress{lastOffset: committedOffset, samples: 1}
+		return
+	}
+	if committedOffset != progress.lastOffset {
+		progress.lastOffset = committedOffset
+		progress.advanced = true
+	}
+	progress.samples++
+}
+
+// hasStalledCommittedOffset reports whether a channel's committed offset stayed put across every poll
+// of the current batch. At least two samples are required so a single observation is never mistaken
+// for a stalled channel.
+func (m *Manager) hasStalledCommittedOffset(channelID string) bool {
+	progress, ok := m.committedOffsets[channelID]
+	return ok && progress.samples >= 2 && !progress.advanced
 }
 
 func (m *Manager) getBulkStatus(ctx context.Context, channelIDs []string) (map[string]*model.StatusResponse, []string, error) {
@@ -923,6 +990,7 @@ func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, 
 			continue
 		}
 		if inProgress {
+			m.recordCommittedOffset(info.ChannelID, statusRes.Offset)
 			inProgressInfos = append(inProgressInfos, info)
 			continue
 		}

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -3092,13 +3092,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.NoError(t, err)
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
+		// The committed offset keeps advancing, so the channel is flushing, just not fast enough.
+		committedOffsets := []string{"0", "1001"}
+		var bulkStatusCalls int
 		sm.api = &mockAPI{
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
 				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					offset := committedOffsets[min(bulkStatusCalls, len(committedOffsets)-1)]
+					bulkStatusCalls++
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
-							"test-products-channel": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"},
+							"test-products-channel": {Valid: true, Success: true, Offset: offset, LatestInsertedOffset: "1003"},
 						},
 					}, nil
 				},
@@ -3107,7 +3112,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			// It reports valid, so the channel is treated as genuinely stuck.
 			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
 				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"}, nil
+					return &model.StatusResponse{Valid: true, Success: true, Offset: "1001", LatestInsertedOffset: "1003"}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -3177,6 +3182,114 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.True(t, second.HasFailed)
 		// Failed via the per-channel invalid path, not the stuck-pipeline path.
 		require.JSONEq(t, second.FailedJobParameters, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"channel reported invalid by per-channel status check after threshold","count":2}]`)
+	})
+
+	t.Run("Poll recovers a channel Snowpipe stopped persisting without stuck-pipeline alert", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			// Snowpipe accepted every row (latestInsertedOffset reaches the expected offset) but its
+			// committed offset never moves: rows are left uncommitted server-side
+			// (snowflake-ingest-java#351).
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1001", LatestInsertedOffset: "1003"},
+						},
+					}, nil
+				},
+			},
+			// The channel itself still reports healthy, which is why this cannot be caught by the
+			// invalid-channel check alone.
+			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
+				"test-products-channel": func() (*model.StatusResponse, error) {
+					return &model.StatusResponse{Valid: true, Success: true, Offset: "1001", LatestInsertedOffset: "1003"}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+		}
+
+		now := time.Now().UTC()
+		sm.now = func() time.Time { return now }
+
+		first := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.True(t, first.InProgress)
+
+		now = now.Add(1 * time.Hour)
+		second := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.False(t, second.InProgress)
+		require.True(t, second.Complete)
+		require.Equal(t, http.StatusOK, second.StatusCode)
+		require.True(t, second.HasFailed)
+		// Recovered via the stalled-offset path, so no stuck-pipeline alert is raised.
+		require.JSONEq(t, second.FailedJobParameters, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"channel valid but its committed offset did not advance before threshold","count":2}]`)
+	})
+
+	t.Run("Committed offset tracking only reports a stall on repeated identical samples", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+
+		// A single sample is never enough to call a channel stalled.
+		sm.recordCommittedOffset("chan-single", "100")
+		require.False(t, sm.hasStalledCommittedOffset("chan-single"))
+
+		// Repeated identical samples mean the committed offset never moved.
+		sm.recordCommittedOffset("chan-single", "100")
+		require.True(t, sm.hasStalledCommittedOffset("chan-single"))
+
+		// Once it advances the channel is no longer stalled, even if it stops moving afterwards.
+		sm.recordCommittedOffset("chan-single", "101")
+		sm.recordCommittedOffset("chan-single", "101")
+		require.False(t, sm.hasStalledCommittedOffset("chan-single"))
+
+		// An unparseable offset is skipped, so it can never push a channel into a stalled verdict.
+		sm.recordCommittedOffset("chan-bad", "not-a-number")
+		sm.recordCommittedOffset("chan-bad", "not-a-number")
+		require.False(t, sm.hasStalledCommittedOffset("chan-bad"))
+
+		// An unknown channel is never reported as stalled.
+		require.False(t, sm.hasStalledCommittedOffset("chan-unknown"))
+	})
+
+	t.Run("Poll drops committed offset samples left behind by a previous batch", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1001", LatestInsertedOffset: "1003"},
+						},
+					}, nil
+				},
+			},
+		}
+
+		// Channels are reused across batches, so a batch that never reached its terminal poll can
+		// leave samples behind. They must not count towards the next batch's stall verdict.
+		sm.committedOffsets["test-products-channel"] = &committedOffsetProgress{lastOffset: 1001, samples: 5}
+		require.True(t, sm.hasStalledCommittedOffset("test-products-channel"))
+
+		first := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.True(t, first.InProgress)
+		// Only the single sample taken by this poll survives, which is not enough to call a stall.
+		require.False(t, sm.hasStalledCommittedOffset("test-products-channel"))
 	})
 
 	t.Run("Poll treats inconclusive single-channel check at threshold as stuck", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -30,6 +30,9 @@ type (
 		api                 api
 		channelCache        sync.Map
 		polledImportInfoMap map[string]*importInfo
+		// Tracks how the committed offset of each in-progress channel moved within the current
+		// batch, used at the stuck threshold to tell a stalled channel from a slow one.
+		committedOffsets map[string]*committedOffsetProgress
 
 		config struct {
 			client struct {
@@ -102,6 +105,17 @@ type (
 		End   int64 `json:"end"`
 	}
 
+	// committedOffsetProgress records how a channel's latest committed offset moved across the polls
+	// of a single batch.
+	committedOffsetProgress struct {
+		lastOffset int64
+		samples    int
+		advanced   bool
+	}
+
+	// stuckChannelCause classifies why a channel was still in progress at the stuck threshold.
+	stuckChannelCause string
+
 	importInfo struct {
 		ChannelID string `json:"channelId"`
 		Offset    string `json:"offset"`
@@ -148,6 +162,16 @@ type (
 		destination  *backendconfig.DestinationT
 		api
 	}
+)
+
+const (
+	// causeChannelInvalid: the per-channel status endpoint positively reports the channel as invalid.
+	causeChannelInvalid stuckChannelCause = "channel_invalid"
+	// causeNotPersisting: the channel is valid and holds every row we sent, but Snowpipe stopped
+	// committing them.
+	causeNotPersisting stuckChannelCause = "not_persisting"
+	// causeStuck: everything else, including an inconclusive status check.
+	causeStuck stuckChannelCause = "stuck"
 )
 
 func (d *destConfig) Decode(m map[string]any) error {


### PR DESCRIPTION
## Description

The `warehouse-snowpipe-stuck` P0 fires on the `Stuck snowpipe pipeline detected` log line. Both firings in the last 7 days fleet-wide were the same Snowflake-side fault, and neither needed a human.

Investigated from the [2026-08-14 alert](https://rudderlabs.slack.com/archives/C02HCJ7MKFF/p1786718344854979) (`entusmtdev`, destination `38xGohVPs9KZQT87IO60nO1iiEi`). One channel — `LINK_CLICKED`, a single event — was the only one actually stuck. Snowflake had accepted the row but never committed it:

```
Get channel status name=RS_CHANNEL_..._LINK_CLICKED_..., status=0,
  endOffsetToken=5625128687, persistedOffsetToken=5625044444
ERROR ChannelStore: Failed to close channel 0ffb27c7...: SFException: One or more channels
  [...LINK_CLICKED...] might contain uncommitted rows due to server side errors
```

`status=0` means the channel still reports **valid**, so `isChannelInvalidViaSingleStatus` could not catch it and `isInProgress` stayed in its "flushing in progress" case for the full 15m threshold. The manager then recovered by itself — failed the batch, deleted and recreated the channel, and the event was retried and landed. The P0 asked for manual intervention that was never needed. See [snowflake-ingest-java#351](https://github.com/snowflakedb/snowflake-ingest-java/issues/351).

## Changes

Classify why a channel was still in progress at the threshold, and only emit the alert line for causes we may have to act on ourselves:

| cause | meaning | alert |
|---|---|---|
| `channel_invalid` | per-channel status reports the channel invalid | no (existing path) |
| `not_persisting` | channel valid, holds every row we sent, committed offset never moved while we polled | no |
| `stuck` | anything else, **including an inconclusive status check** | **yes** |

Recovery behaviour is unchanged — every cause is still failed and retried exactly as before. Only which of them raises the alert changes.

The committed offset is sampled from the value already returned by bulk status, which our snowpipe service derives from the public `getLatestCommittedOffsetToken()` (`ChannelsResource.java:127`). No internal SDK fields (`rowSequencer` and friends) are used. Samples are scoped to a batch and dropped when a new batch starts, since channels are reused across batches.

Also logs only the stuck channels rather than the whole import ID — the 2026-08-14 alert listed four channels when three of them had already flushed successfully, which is what made triage slow.

No `rudder-devops` change: the alert rule still matches on the same log line, it just gets emitted less often.

## Fail-safe

`stuck` remains the default. An errored status check, a channel with too few samples to judge, or any committed offset that did move still alerts. The new suppression requires positive evidence on both axes: a **successful** status check reporting valid, **and** an offset observed unmoved across at least two polls.

## Testing

`go test ./router/batchrouter/asyncdestinationmanager/snowpipestreaming/...` passes. Added coverage for:
- a channel Snowpipe stopped persisting recovers without the alert
- a slow-but-advancing channel still alerts (existing test, now given an advancing offset so it stays a genuine stuck case)
- an inconclusive status check still alerts (unchanged)
- offset-tracking guards: minimum samples, advance resets the verdict, unparseable offsets skipped
- samples from a previous batch do not leak into the next one

## Follow-ups, not in this PR

- The stuck path sets `info.Failed` but leaves `info.FailedJobIds` nil, so `GetUploadStats:1145` fails **every** job of that table, including rows Snowflake already committed — a duplicate-row risk on multi-row stuck batches (the 2026-08-12 firing had 65 `IDENTIFIES` and 69 `PAGES` in scope). The "events lost" path already computes `Start: latestCommittedOffset+1, End: expectedOffset`; the stuck path should do the same.
- `rudder-snowpipe-clients` swallows the close-time `SFException` into a Java-side log while rudder-server sees only a 404 on delete. Propagating it would turn the Snowflake attribution from inferred into confirmed, without needing a second container's logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)