### PR TITLE
feat: backend config v2 resolver with stub mapper

### DIFF
--- a/backend-config/backend-config.go
+++ b/backend-config/backend-config.go
@@ -273,7 +273,7 @@ func (bc *backendConfigImpl) Subscribe(ctx context.Context, topic Topic) pubsub.
 	return bc.eb.Subscribe(ctx, string(topic))
 }
 
-func newForDeployment(deploymentType deployment.Type, region string, configEnvHandler types.ConfigEnvI) (BackendConfig, error) {
+func newForDeployment(deploymentType deployment.Type, configEnvHandler types.ConfigEnvI) (BackendConfig, error) {
 	backendConfig := &backendConfigImpl{
 		eb: pubsub.New(),
 	}
@@ -288,14 +288,12 @@ func newForDeployment(deploymentType deployment.Type, region string, configEnvHa
 			configJSONPath:   configJSONPath,
 			configBackendURL: parsedConfigBackendURL,
 			configEnvHandler: configEnvHandler,
-			region:           region,
 		}
 	case deployment.MultiTenantType:
 		backendConfig.workspaceConfig = &namespaceConfig{
 			configBackendURL:         parsedConfigBackendURL,
 			configEnvHandler:         configEnvHandler,
 			cpRouterURL:              cpRouterURL,
-			region:                   region,
 			incrementalConfigUpdates: incrementalConfigUpdates,
 		}
 	default:
@@ -308,12 +306,11 @@ func newForDeployment(deploymentType deployment.Type, region string, configEnvHa
 // Setup backend config
 func Setup(configEnvHandler types.ConfigEnvI) (err error) {
 	deploymentType, err := deployment.GetFromEnv()
-	region := config.GetStringVar("", "region")
 	if err != nil {
 		return fmt.Errorf("deployment type from env: %w", err)
 	}
 
-	backendConfig, err := newForDeployment(deploymentType, region, configEnvHandler)
+	backendConfig, err := newForDeployment(deploymentType, configEnvHandler)
 	if err != nil {
 		return err
 	}

--- a/backend-config/backend_config_test.go
+++ b/backend-config/backend_config_test.go
@@ -177,15 +177,19 @@ func TestBadResponse(t *testing.T) {
 	parsedURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
+	nsConfig := &namespaceConfig{
+		config:              config.New(),
+		configBackendURL:    parsedURL,
+		namespace:           "some-namespace",
+		hostedServiceSecret: "some-secret",
+		client:              http.DefaultClient,
+		logger:              logger.NOP,
+		stats:               stats.NOP,
+	}
+	require.NoError(t, nsConfig.SetUp())
+
 	configs := map[string]workspaceConfig{
-		"namespace": &namespaceConfig{
-			configBackendURL:     parsedURL,
-			namespace:            "some-namespace",
-			client:               http.DefaultClient,
-			logger:               logger.NOP,
-			httpCallsStat:        stats.NOP.NewStat("backend_config_http_calls", stats.CountType),
-			httpResponseSizeStat: stats.NOP.NewStat("backend_config_http_response_size", stats.HistogramType),
-		},
+		"namespace": nsConfig,
 		"single-workspace": &singleWorkspaceConfig{
 			configBackendURL:     parsedURL,
 			logger:               logger.NOP,

--- a/backend-config/backend_config_test.go
+++ b/backend-config/backend_config_test.go
@@ -231,7 +231,7 @@ func TestNewForDeployment(t *testing.T) {
 	initBackendConfig()
 	t.Run("dedicated", func(t *testing.T) {
 		t.Setenv("WORKSPACE_TOKEN", "foobar")
-		conf, err := newForDeployment(deployment.DedicatedType, "US", nil)
+		conf, err := newForDeployment(deployment.DedicatedType, nil)
 		require.NoError(t, err)
 		cb, ok := conf.(*backendConfigImpl)
 		require.True(t, ok)
@@ -242,7 +242,7 @@ func TestNewForDeployment(t *testing.T) {
 	t.Run("multi-tenant", func(t *testing.T) {
 		t.Setenv("WORKSPACE_NAMESPACE", "spaghetti")
 		t.Setenv("HOSTED_SERVICE_SECRET", "foobar")
-		conf, err := newForDeployment(deployment.MultiTenantType, "", nil)
+		conf, err := newForDeployment(deployment.MultiTenantType, nil)
 		require.NoError(t, err)
 
 		cb, ok := conf.(*backendConfigImpl)
@@ -252,7 +252,7 @@ func TestNewForDeployment(t *testing.T) {
 	})
 
 	t.Run("unsupported", func(t *testing.T) {
-		_, err := newForDeployment("UNSUPPORTED_TYPE", "", nil)
+		_, err := newForDeployment("UNSUPPORTED_TYPE", nil)
 		require.ErrorContains(t, err, `deployment type "UNSUPPORTED_TYPE" not supported`)
 	})
 }

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -41,7 +41,6 @@ type namespaceConfig struct {
 
 	namespace                string
 	configBackendURL         *url.URL
-	region                   string
 	incrementalConfigUpdates bool
 
 	fetcher configFetcher
@@ -84,6 +83,8 @@ func (nc *namespaceConfig) SetUp() (err error) {
 		nc.logger = logger.NewLogger().Child("backend-config").Withn(obskit.Namespace(nc.namespace))
 	}
 
+	// the mode is fixed at setup. v2 is not selectable yet, see
+	// newV2ConfigFetcher
 	nc.fetcher = newV1ConfigFetcher(nc)
 
 	nc.logger.Infon("Setup backend config complete")

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -3,24 +3,16 @@ package backendconfig
 import (
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/cenkalti/backoff/v5"
-
 	"github.com/rudderlabs/rudder-go-kit/config"
-	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
-	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
-	"github.com/rudderlabs/rudder-server/backend-config/dynamicconfig"
 	"github.com/rudderlabs/rudder-server/services/controlplane/identity"
-	"github.com/rudderlabs/rudder-server/utils/backoffvoid"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -29,6 +21,13 @@ var (
 	ErrIncrementalUpdateFailed = errors.New("incremental update failed")
 )
 
+// configFetcher fetches the configs of all workspaces in a namespace, keyed by workspace ID.
+// Implementations own their own incremental update state and are responsible for
+// recovering from a failed incremental update.
+type configFetcher interface {
+	Get(ctx context.Context) (map[string]ConfigT, error)
+}
+
 type namespaceConfig struct {
 	configEnvHandler types.ConfigEnvI
 	cpRouterURL      string
@@ -36,6 +35,7 @@ type namespaceConfig struct {
 	config *config.Config
 	logger logger.Logger
 	client *http.Client
+	stats  stats.Stats
 
 	hostedServiceSecret string
 
@@ -43,12 +43,8 @@ type namespaceConfig struct {
 	configBackendURL         *url.URL
 	region                   string
 	incrementalConfigUpdates bool
-	lastUpdatedAt            time.Time
-	workspacesConfig         map[string]ConfigT
-	dynamicConfigCache       dynamicconfig.Cache
 
-	httpCallsStat        stats.Counter
-	httpResponseSizeStat stats.Histogram
+	fetcher configFetcher
 }
 
 func (nc *namespaceConfig) SetUp() (err error) {
@@ -79,154 +75,25 @@ func (nc *namespaceConfig) SetUp() (err error) {
 			Timeout: nc.config.GetDurationVar(30, time.Second, "HttpClient.backendConfig.timeout"),
 		}
 	}
-	nc.workspacesConfig = make(map[string]ConfigT)
-	nc.dynamicConfigCache = make(DynamicConfigMapCache)
-	nc.httpCallsStat = stats.Default.NewStat("backend_config_http_calls", stats.CountType)
-	nc.httpResponseSizeStat = stats.Default.NewStat("backend_config_http_response_size", stats.HistogramType)
+
+	if nc.stats == nil {
+		nc.stats = stats.Default
+	}
 
 	if nc.logger == nil {
 		nc.logger = logger.NewLogger().Child("backend-config").Withn(obskit.Namespace(nc.namespace))
 	}
+
+	nc.fetcher = newV1ConfigFetcher(nc)
+
 	nc.logger.Infon("Setup backend config complete")
 
 	return nil
 }
 
-// Get returns sources from the workspace
+// Get returns the configs of all workspaces in the namespace
 func (nc *namespaceConfig) Get(ctx context.Context) (map[string]ConfigT, error) {
-	conf, err := nc.getFromAPI(ctx)
-	if errors.Is(err, ErrIncrementalUpdateFailed) {
-		// reset state here
-		// this triggers a full update
-		nc.lastUpdatedAt = time.Time{}
-		return nc.getFromAPI(ctx)
-	}
-	return conf, err
-}
-
-// getFromApi gets the workspace config from api
-func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, error) {
-	configOnError := make(map[string]ConfigT)
-	if nc.namespace == "" {
-		return configOnError, fmt.Errorf("namespace is not configured")
-	}
-
-	var respBody []byte
-	u := *nc.configBackendURL
-	u.Path = fmt.Sprintf("/data-plane/v1/namespaces/%s/config", nc.namespace)
-	if nc.incrementalConfigUpdates && !nc.lastUpdatedAt.IsZero() {
-		values := u.Query()
-		values.Add("updatedAfter", nc.lastUpdatedAt.Format(updatedAfterTimeFormat))
-		u.RawQuery = values.Encode()
-	}
-
-	urlString := u.String()
-	req, err := nc.prepareHTTPRequest(ctx, urlString)
-	if err != nil {
-		return configOnError, fmt.Errorf("error preparing request: %s: %w", urlString, err)
-	}
-
-	operation := func() (fetchError error) {
-		defer nc.httpCallsStat.Increment()
-		nc.logger.Debugn("Fetching backend config", logger.NewStringField("url", urlString))
-		respBody, fetchError = nc.makeHTTPRequest(req)
-		return fetchError
-	}
-
-	err = backoffvoid.Retry(ctx, operation,
-		backoff.WithMaxTries(3+1),
-		backoff.WithNotify(func(err error, t time.Duration) {
-			nc.logger.Warnn("Failed to fetch backend config from API",
-				obskit.Error(err), logger.NewDurationField("retryAfter", t),
-			)
-		}),
-	)
-	if err != nil {
-		if ctx.Err() == nil {
-			nc.logger.Errorn("Error sending request to the server", obskit.Error(err))
-		}
-		return configOnError, err
-	}
-	configEnvHandler := nc.configEnvHandler
-	if configEnvReplacementEnabled && configEnvHandler != nil {
-		respBody = configEnvHandler.ReplaceConfigWithEnvVariables(respBody)
-	}
-
-	var requestData map[string]*ConfigT
-	err = jsonrs.Unmarshal(respBody, &requestData)
-	if err != nil {
-		nc.logger.Errorn("Error while parsing request", obskit.Error(err))
-		return configOnError, err
-	}
-
-	workspacesConfig := make(map[string]ConfigT, len(requestData))
-	for workspaceID, workspace := range requestData {
-		if workspace == nil { // this workspace was not updated, populate it with the previous config
-			previousConfig, ok := nc.workspacesConfig[workspaceID]
-			if !ok {
-				nc.logger.Errorn(
-					"workspace was not updated but was not present in previous config",
-					obskit.WorkspaceID(workspaceID),
-					logger.NewStringField("requestURL", req.URL.String()),
-				)
-				return configOnError, ErrIncrementalUpdateFailed
-			}
-			workspace = &previousConfig
-		} else {
-			workspace.ApplyReplaySources()
-			workspace.processAccountAssociations()
-			// Process dynamic config with the instance cache
-			ProcessDestinationsInSources(workspace.Sources, nc.dynamicConfigCache)
-		}
-		// always set connection flags to true for hosted and multi-tenant warehouse and processor services
-		workspace.ConnectionFlags.URL = nc.cpRouterURL
-		workspace.ConnectionFlags.Services = map[string]bool{"warehouse": true, "rudderstack-processor": true}
-		workspacesConfig[workspaceID] = *workspace
-		if nc.incrementalConfigUpdates && workspace.UpdatedAt.After(nc.lastUpdatedAt) {
-			nc.lastUpdatedAt = workspace.UpdatedAt
-		}
-	}
-
-	nc.workspacesConfig = workspacesConfig
-
-	return nc.workspacesConfig, nil
-}
-
-func (nc *namespaceConfig) prepareHTTPRequest(ctx context.Context, url string) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
-	if err != nil {
-		return nil, err
-	}
-
-	req.SetBasicAuth(nc.Identity().BasicAuth())
-	if nc.region != "" {
-		q := req.URL.Query()
-		q.Add("region", nc.region)
-		req.URL.RawQuery = q.Encode()
-	}
-
-	return req, nil
-}
-
-func (nc *namespaceConfig) makeHTTPRequest(req *http.Request) ([]byte, error) {
-	resp, err := nc.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() { kithttputil.CloseResponse(resp) }()
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	nc.httpResponseSizeStat.Observe(float64(len(respBody)))
-
-	if resp.StatusCode >= 300 {
-		return nil, getNotOKError(respBody, resp.StatusCode)
-	}
-
-	return respBody, nil
+	return nc.fetcher.Get(ctx)
 }
 
 func (nc *namespaceConfig) AccessToken() string {

--- a/backend-config/namespace_config_test.go
+++ b/backend-config/namespace_config_test.go
@@ -337,7 +337,7 @@ func Test_Namespace_IncrementalUpdates(t *testing.T) {
 	expectedUpdatedAt, err = time.Parse(updatedAfterTimeFormat, "2022-07-20T10:00:00.000Z")
 	require.NoError(t, err)
 	require.Equal(t, receivedUpdatedAfter[0], expectedUpdatedAt, updatedAfterTimeFormat)
-	require.Equal(t, receivedUpdatedAfter[0], client.lastUpdatedAt, updatedAfterTimeFormat)
+	require.Equal(t, receivedUpdatedAfter[0], client.fetcher.(*v1ConfigFetcher).lastUpdatedAt, updatedAfterTimeFormat)
 	require.Equal(t, 7, requestNumber)
 }
 

--- a/backend-config/namespace_config_v1.go
+++ b/backend-config/namespace_config_v1.go
@@ -1,0 +1,204 @@
+package backendconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+
+	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
+	"github.com/rudderlabs/rudder-server/backend-config/dynamicconfig"
+	"github.com/rudderlabs/rudder-server/services/controlplane/identity"
+	"github.com/rudderlabs/rudder-server/utils/backoffvoid"
+	"github.com/rudderlabs/rudder-server/utils/types"
+)
+
+// v1ConfigFetcher fetches the namespace's workspace configs from the v1
+// data-plane endpoint, which already serves them as ConfigT.
+type v1ConfigFetcher struct {
+	logger           logger.Logger
+	client           *http.Client
+	configEnvHandler types.ConfigEnvI
+
+	namespace                string
+	identity                 identity.Identifier
+	configBackendURL         *url.URL
+	region                   string
+	cpRouterURL              string
+	incrementalConfigUpdates bool
+
+	lastUpdatedAt      time.Time
+	workspacesConfig   map[string]ConfigT
+	dynamicConfigCache dynamicconfig.Cache
+
+	httpCallsStat        stats.Counter
+	httpResponseSizeStat stats.Histogram
+}
+
+func newV1ConfigFetcher(nc *namespaceConfig) *v1ConfigFetcher {
+	return &v1ConfigFetcher{
+		logger:           nc.logger,
+		client:           nc.client,
+		configEnvHandler: nc.configEnvHandler,
+
+		namespace:                nc.namespace,
+		identity:                 nc.Identity(),
+		configBackendURL:         nc.configBackendURL,
+		region:                   nc.region,
+		cpRouterURL:              nc.cpRouterURL,
+		incrementalConfigUpdates: nc.incrementalConfigUpdates,
+
+		workspacesConfig:   make(map[string]ConfigT),
+		dynamicConfigCache: make(DynamicConfigMapCache),
+
+		httpCallsStat:        nc.stats.NewStat("backend_config_http_calls", stats.CountType),
+		httpResponseSizeStat: nc.stats.NewStat("backend_config_http_response_size", stats.HistogramType),
+	}
+}
+
+// Get returns the configs of all workspaces in the namespace
+func (f *v1ConfigFetcher) Get(ctx context.Context) (map[string]ConfigT, error) {
+	conf, err := f.getFromAPI(ctx)
+	if errors.Is(err, ErrIncrementalUpdateFailed) {
+		// reset state here
+		// this triggers a full update
+		f.lastUpdatedAt = time.Time{}
+		return f.getFromAPI(ctx)
+	}
+	return conf, err
+}
+
+// getFromAPI gets the workspace config from api
+func (f *v1ConfigFetcher) getFromAPI(ctx context.Context) (map[string]ConfigT, error) {
+	configOnError := make(map[string]ConfigT)
+	if f.namespace == "" {
+		return configOnError, fmt.Errorf("namespace is not configured")
+	}
+
+	var respBody []byte
+	u := *f.configBackendURL
+	u.Path = fmt.Sprintf("/data-plane/v1/namespaces/%s/config", f.namespace)
+	if f.incrementalConfigUpdates && !f.lastUpdatedAt.IsZero() {
+		values := u.Query()
+		values.Add("updatedAfter", f.lastUpdatedAt.Format(updatedAfterTimeFormat))
+		u.RawQuery = values.Encode()
+	}
+
+	urlString := u.String()
+	req, err := f.prepareHTTPRequest(ctx, urlString)
+	if err != nil {
+		return configOnError, fmt.Errorf("error preparing request: %s: %w", urlString, err)
+	}
+
+	operation := func() (fetchError error) {
+		defer f.httpCallsStat.Increment()
+		f.logger.Debugn("Fetching backend config", logger.NewStringField("url", urlString))
+		respBody, fetchError = f.makeHTTPRequest(req)
+		return fetchError
+	}
+
+	err = backoffvoid.Retry(ctx, operation,
+		backoff.WithMaxTries(3+1),
+		backoff.WithNotify(func(err error, t time.Duration) {
+			f.logger.Warnn("Failed to fetch backend config from API",
+				obskit.Error(err), logger.NewDurationField("retryAfter", t),
+			)
+		}),
+	)
+	if err != nil {
+		if ctx.Err() == nil {
+			f.logger.Errorn("Error sending request to the server", obskit.Error(err))
+		}
+		return configOnError, err
+	}
+	configEnvHandler := f.configEnvHandler
+	if configEnvReplacementEnabled && configEnvHandler != nil {
+		respBody = configEnvHandler.ReplaceConfigWithEnvVariables(respBody)
+	}
+
+	var requestData map[string]*ConfigT
+	err = jsonrs.Unmarshal(respBody, &requestData)
+	if err != nil {
+		f.logger.Errorn("Error while parsing request", obskit.Error(err))
+		return configOnError, err
+	}
+
+	workspacesConfig := make(map[string]ConfigT, len(requestData))
+	for workspaceID, workspace := range requestData {
+		if workspace == nil { // this workspace was not updated, populate it with the previous config
+			previousConfig, ok := f.workspacesConfig[workspaceID]
+			if !ok {
+				f.logger.Errorn(
+					"workspace was not updated but was not present in previous config",
+					obskit.WorkspaceID(workspaceID),
+					logger.NewStringField("requestURL", req.URL.String()),
+				)
+				return configOnError, ErrIncrementalUpdateFailed
+			}
+			workspace = &previousConfig
+		} else {
+			workspace.ApplyReplaySources()
+			workspace.processAccountAssociations()
+			// Process dynamic config with the instance cache
+			ProcessDestinationsInSources(workspace.Sources, f.dynamicConfigCache)
+		}
+		// always set connection flags to true for hosted and multi-tenant warehouse and processor services
+		workspace.ConnectionFlags.URL = f.cpRouterURL
+		workspace.ConnectionFlags.Services = map[string]bool{"warehouse": true, "rudderstack-processor": true}
+		workspacesConfig[workspaceID] = *workspace
+		if f.incrementalConfigUpdates && workspace.UpdatedAt.After(f.lastUpdatedAt) {
+			f.lastUpdatedAt = workspace.UpdatedAt
+		}
+	}
+
+	f.workspacesConfig = workspacesConfig
+
+	return f.workspacesConfig, nil
+}
+
+func (f *v1ConfigFetcher) prepareHTTPRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(f.identity.BasicAuth())
+	if f.region != "" {
+		q := req.URL.Query()
+		q.Add("region", f.region)
+		req.URL.RawQuery = q.Encode()
+	}
+
+	return req, nil
+}
+
+func (f *v1ConfigFetcher) makeHTTPRequest(req *http.Request) ([]byte, error) {
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { kithttputil.CloseResponse(resp) }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	f.httpResponseSizeStat.Observe(float64(len(respBody)))
+
+	if resp.StatusCode >= 300 {
+		return nil, getNotOKError(respBody, resp.StatusCode)
+	}
+
+	return respBody, nil
+}

--- a/backend-config/namespace_config_v1.go
+++ b/backend-config/namespace_config_v1.go
@@ -33,7 +33,6 @@ type v1ConfigFetcher struct {
 	namespace                string
 	identity                 identity.Identifier
 	configBackendURL         *url.URL
-	region                   string
 	cpRouterURL              string
 	incrementalConfigUpdates bool
 
@@ -54,7 +53,6 @@ func newV1ConfigFetcher(nc *namespaceConfig) *v1ConfigFetcher {
 		namespace:                nc.namespace,
 		identity:                 nc.Identity(),
 		configBackendURL:         nc.configBackendURL,
-		region:                   nc.region,
 		cpRouterURL:              nc.cpRouterURL,
 		incrementalConfigUpdates: nc.incrementalConfigUpdates,
 
@@ -173,11 +171,6 @@ func (f *v1ConfigFetcher) prepareHTTPRequest(ctx context.Context, url string) (*
 	}
 
 	req.SetBasicAuth(f.identity.BasicAuth())
-	if f.region != "" {
-		q := req.URL.Query()
-		q.Add("region", f.region)
-		req.URL.RawQuery = q.Encode()
-	}
 
 	return req, nil
 }

--- a/backend-config/namespace_config_v2.go
+++ b/backend-config/namespace_config_v2.go
@@ -1,0 +1,292 @@
+package backendconfig
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+
+	cpsdk "github.com/rudderlabs/rudder-cp-sdk"
+	"github.com/rudderlabs/rudder-cp-sdk/diff"
+	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
+	"github.com/rudderlabs/rudder-server/backend-config/dynamicconfig"
+	"github.com/rudderlabs/rudder-server/utils/backoffvoid"
+	"github.com/rudderlabs/rudder-server/utils/types"
+)
+
+// v2ConfigFetcher fetches the namespace's workspace configs from the v2 endpoint, which serves
+// them in a shape of its own, and maps each one to a v1 ConfigT.
+type v2ConfigFetcher struct {
+	logger logger.Logger
+	client v2Client
+	mapper mapper
+
+	cpRouterURL              string
+	incrementalConfigUpdates bool
+
+	updater            diff.Updater[string]
+	cache              v2NamespaceConfig
+	lastUpdatedAt      time.Time
+	memo               map[string]v2MemoEntry
+	dynamicConfigCache dynamicconfig.Cache
+
+	httpCallsStat stats.Counter
+}
+
+// v2Client is the part of the control plane SDK this fetcher needs.
+type v2Client interface {
+	GetWorkspaceConfigs(ctx context.Context, object any, updatedAfter time.Time) error
+}
+
+// v2MemoEntry is a workspace's last transform, kept so that a poll in which the workspace did not
+// change, and neither did the definitions it was mapped against, can skip the transform entirely.
+type v2MemoEntry struct {
+	generation v2Generation
+	config     ConfigT
+}
+
+func newV2ConfigFetcher(nc *namespaceConfig) (*v2ConfigFetcher, error) {
+	httpCallsStat := nc.stats.NewStat("backend_config_http_calls", stats.CountType)
+
+	client, err := cpsdk.New(
+		cpsdk.WithNamespaceIdentity(nc.namespace, nc.hostedServiceSecret),
+		// both versions are served from the same host, the one CONFIG_BACKEND_URL points at
+		cpsdk.WithBaseUrl(nc.configBackendURL.String()),
+		// account secrets are embedded in the response, as v1 serves them: without this the
+		// destinations arrive without their credentials and every delivery fails authentication
+		cpsdk.WithSecrets(cpsdk.SecretsEmbed),
+		cpsdk.WithRequestDoer(&v2RequestDoer{
+			doer:                 nc.client,
+			configEnvHandler:     nc.configEnvHandler,
+			httpResponseSizeStat: nc.stats.NewStat("backend_config_http_response_size", stats.HistogramType),
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating control plane client: %w", err)
+	}
+
+	return &v2ConfigFetcher{
+		logger:                   nc.logger.Withn(logger.NewStringField("configVersion", "v2")),
+		client:                   client,
+		mapper:                   &stubMapper{},
+		cpRouterURL:              nc.cpRouterURL,
+		incrementalConfigUpdates: nc.incrementalConfigUpdates,
+		memo:                     make(map[string]v2MemoEntry),
+		dynamicConfigCache:       make(DynamicConfigMapCache),
+		httpCallsStat:            httpCallsStat,
+	}, nil
+}
+
+// Get returns the configs of all workspaces in the namespace
+func (f *v2ConfigFetcher) Get(ctx context.Context) (map[string]ConfigT, error) {
+	conf, err := f.getFromAPI(ctx)
+	if errors.Is(err, ErrIncrementalUpdateFailed) {
+		// the cache can no longer be reconciled with what the control plane is sending,
+		// so drop it and ask for everything
+		f.reset()
+		return f.getFromAPI(ctx)
+	}
+	return conf, err
+}
+
+// reset drops everything that was accumulated across polls, so that the next request asks for the
+// full config rather than for a delta.
+func (f *v2ConfigFetcher) reset() {
+	f.updater = diff.Updater[string]{}
+	f.cache = v2NamespaceConfig{}
+	f.lastUpdatedAt = time.Time{}
+	f.memo = make(map[string]v2MemoEntry)
+}
+
+func (f *v2ConfigFetcher) getFromAPI(ctx context.Context) (map[string]ConfigT, error) {
+	configOnError := make(map[string]ConfigT)
+
+	var response v2NamespaceConfig
+	operation := func() error {
+		defer f.httpCallsStat.Increment()
+		response = v2NamespaceConfig{} // a retry must not decode on top of a half filled response
+		var updatedAfter time.Time
+		if f.incrementalConfigUpdates {
+			updatedAfter = f.lastUpdatedAt
+		}
+		return f.client.GetWorkspaceConfigs(ctx, &response, updatedAfter)
+	}
+
+	err := backoffvoid.Retry(ctx, operation,
+		backoff.WithMaxTries(3+1),
+		backoff.WithNotify(func(err error, t time.Duration) {
+			f.logger.Warnn("Failed to fetch backend config from API",
+				obskit.Error(err), logger.NewDurationField("retryAfter", t),
+			)
+		}),
+	)
+	if err != nil {
+		if ctx.Err() == nil {
+			f.logger.Errorn("Error sending request to the server", obskit.Error(err))
+		}
+		return configOnError, err
+	}
+
+	if response.Version != v2ConfigVersion {
+		return configOnError, fmt.Errorf("unexpected config version %d, expected %d", response.Version, v2ConfigVersion)
+	}
+	// both the members and the changed set are read here, off the response and before the cache
+	// is updated: UpdateCache writes cached workspaces back over the nils
+	members := make([]string, 0, len(response.Workspaces))
+	changed := make(map[string]struct{}, len(response.Workspaces))
+	for workspaceID, workspace := range response.Workspaces {
+		members = append(members, workspaceID)
+		if workspace != nil {
+			changed[workspaceID] = struct{}{}
+		}
+	}
+
+	lastUpdatedAt, _, err := f.updater.UpdateCache(&response, &f.cache)
+	if err != nil {
+		return configOnError, fmt.Errorf("%w: %w", ErrIncrementalUpdateFailed, err)
+	}
+	f.lastUpdatedAt = lastUpdatedAt
+
+	generation := f.cache.generation()
+	workspacesConfig := make(map[string]ConfigT, len(members))
+	memo := make(map[string]v2MemoEntry, len(members))
+	for _, workspaceID := range members {
+		workspace := response.Workspaces[workspaceID]
+		if workspace == nil { // UpdateCache should have filled this one in from the cache
+			f.logger.Errorn("workspace was not updated but was not present in previous config",
+				obskit.WorkspaceID(workspaceID),
+			)
+			return configOnError, ErrIncrementalUpdateFailed
+		}
+
+		config, memoized := f.memoized(workspaceID, changed, generation)
+		if !memoized {
+			config, err = f.mapper.Map(workspaceID, workspace.Raw, f.cache.v2Catalogues)
+			if err != nil {
+				return configOnError, fmt.Errorf("mapping workspace %q: %w", workspaceID, err)
+			}
+			config.ApplyReplaySources()
+			config.processAccountAssociations()
+			// Process dynamic config with the instance cache
+			ProcessDestinationsInSources(config.Sources, f.dynamicConfigCache)
+		}
+		memo[workspaceID] = v2MemoEntry{generation: generation, config: config}
+
+		// always set connection flags to true for hosted and multi-tenant warehouse and processor services
+		config.ConnectionFlags.URL = f.cpRouterURL
+		config.ConnectionFlags.Services = map[string]bool{"warehouse": true, "rudderstack-processor": true}
+		workspacesConfig[workspaceID] = config
+	}
+	// rebuilt rather than updated, so that a workspace which left the namespace leaves the memo with it
+	f.memo = memo
+
+	return workspacesConfig, nil
+}
+
+// memoized returns the workspace's last transform, if it can still stand in for a new one.
+func (f *v2ConfigFetcher) memoized(workspaceID string, changed map[string]struct{}, generation v2Generation) (ConfigT, bool) {
+	if _, ok := changed[workspaceID]; ok {
+		return ConfigT{}, false
+	}
+	entry, ok := f.memo[workspaceID]
+	if !ok || entry.generation != generation {
+		return ConfigT{}, false
+	}
+	return entry.config, true
+}
+
+// v2Generation identifies a state of the definition catalogues, which every workspace is mapped
+// against. Cardinalities are part of it because a deletion bumps no timestamp.
+//
+// It is compared with ==, which is safe for the time it holds: that only ever comes off the wire,
+// so it carries no monotonic clock reading, the one thing == would read and Equal would not.
+type v2Generation struct {
+	maxUpdatedAt                             time.Time
+	sourceDefs, destinationDefs, accountDefs int
+}
+
+func (c *v2NamespaceConfig) generation() v2Generation {
+	generation := v2Generation{
+		sourceDefs:      len(c.SourceDefinitions),
+		destinationDefs: len(c.DestinationDefinitions),
+		accountDefs:     len(c.AccountDefinitions),
+	}
+	generation.maxUpdatedAt = newestOf(generation.maxUpdatedAt, c.SourceDefinitions)
+	generation.maxUpdatedAt = newestOf(generation.maxUpdatedAt, c.DestinationDefinitions)
+	generation.maxUpdatedAt = newestOf(generation.maxUpdatedAt, c.AccountDefinitions)
+	return generation
+}
+
+// newestOf returns the later of newest and the most recently updated entry of the catalogue.
+func newestOf[M ~map[string]T, T interface{ updatedAt() time.Time }](newest time.Time, catalogue M) time.Time {
+	for _, definition := range catalogue {
+		if updatedAt := definition.updatedAt(); updatedAt.After(newest) {
+			newest = updatedAt
+		}
+	}
+	return newest
+}
+
+// v2RequestDoer carries over what the SDK's client does not do itself: the environment variable
+// replacement v1 applies to the payload, and the response size stat.
+type v2RequestDoer struct {
+	doer                 *http.Client
+	configEnvHandler     types.ConfigEnvI
+	httpResponseSizeStat stats.Histogram
+}
+
+func (d *v2RequestDoer) Do(req *http.Request) (*http.Response, error) {
+	resp, err := d.doer.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	configEnvHandler := d.configEnvHandler
+	if configEnvReplacementEnabled && configEnvHandler != nil {
+		// the replacement needs the whole document, so this is the one case the response cannot
+		// be decoded as it arrives
+		defer func() { kithttputil.CloseResponse(resp) }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading response body: %w", err)
+		}
+		d.httpResponseSizeStat.Observe(float64(len(body)))
+		replaced := configEnvHandler.ReplaceConfigWithEnvVariables(body)
+		return &http.Response{
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header,
+			Body:       io.NopCloser(bytes.NewReader(replaced)),
+		}, nil
+	}
+
+	resp.Body = &observedReadCloser{ReadCloser: resp.Body, observe: d.httpResponseSizeStat.Observe}
+	return resp, nil
+}
+
+// observedReadCloser reports how much was read out of it once it is closed.
+type observedReadCloser struct {
+	io.ReadCloser
+	read    int
+	observe func(float64)
+}
+
+func (r *observedReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *observedReadCloser) Close() error {
+	r.observe(float64(r.read))
+	return r.ReadCloser.Close()
+}

--- a/backend-config/namespace_config_v2.go
+++ b/backend-config/namespace_config_v2.go
@@ -139,6 +139,13 @@ func (f *v2ConfigFetcher) getFromAPI(ctx context.Context) (map[string]ConfigT, e
 	if response.Version != v2ConfigVersion {
 		return configOnError, fmt.Errorf("unexpected config version %d, expected %d", response.Version, v2ConfigVersion)
 	}
+	if len(response.Workspaces) == 0 { // zero workspaces means invalid response
+		if !f.lastUpdatedAt.IsZero() { // by returning ErrIncrementalUpdateFailed we force to reset lastUpdatedAt amd retry
+			return configOnError, fmt.Errorf("%w: no workspaces in response", ErrIncrementalUpdateFailed)
+		}
+		return configOnError, fmt.Errorf("no workspaces in response")
+	}
+
 	// both the members and the changed set are read here, off the response and before the cache
 	// is updated: UpdateCache writes cached workspaces back over the nils
 	members := make([]string, 0, len(response.Workspaces))
@@ -154,7 +161,6 @@ func (f *v2ConfigFetcher) getFromAPI(ctx context.Context) (map[string]ConfigT, e
 	if err != nil {
 		return configOnError, fmt.Errorf("%w: %w", ErrIncrementalUpdateFailed, err)
 	}
-	f.lastUpdatedAt = lastUpdatedAt
 
 	generation := f.cache.generation()
 	workspacesConfig := make(map[string]ConfigT, len(members))
@@ -186,6 +192,8 @@ func (f *v2ConfigFetcher) getFromAPI(ctx context.Context) (map[string]ConfigT, e
 		config.ConnectionFlags.Services = map[string]bool{"warehouse": true, "rudderstack-processor": true}
 		workspacesConfig[workspaceID] = config
 	}
+	// both lastUpdatedAt & memo should move together once the whole poll has succeeded
+	f.lastUpdatedAt = lastUpdatedAt
 	// rebuilt rather than updated, so that a workspace which left the namespace leaves the memo with it
 	f.memo = memo
 

--- a/backend-config/namespace_config_v2_diff.go
+++ b/backend-config/namespace_config_v2_diff.go
@@ -1,0 +1,124 @@
+package backendconfig
+
+import (
+	"iter"
+	"time"
+
+	"github.com/rudderlabs/rudder-cp-sdk/diff"
+)
+
+// The v2 response is merged into the cached one by the SDK's differ, which needs the response to
+// describe which of its lists carry incremental updates and which are replaced wholesale.
+//
+// Workspaces are updateable: a poll with updatedAfter returns null for every workspace that did
+// not change, and the differ fills those back in from the cache. Definitions are not: the control
+// plane always sends the catalogues in full, so they are replaced on every poll - which is also
+// the only way a deleted definition ever leaves the cache.
+var (
+	_ diff.UpdateableObject[string]                       = &v2NamespaceConfig{}
+	_ diff.UpdateableList[string, diff.UpdateableElement] = &v2Workspaces{}
+	_ diff.UpdateableElement                              = &v2Workspace{}
+	_ diff.NonUpdateablesList[string, any]                = &v2SourceDefinitions{}
+	_ diff.NonUpdateablesList[string, any]                = &v2DestinationDefinitions{}
+	_ diff.NonUpdateablesList[string, any]                = &v2AccountDefinitions{}
+)
+
+func (c *v2NamespaceConfig) Updateables() iter.Seq[diff.UpdateableList[string, diff.UpdateableElement]] {
+	return func(yield func(diff.UpdateableList[string, diff.UpdateableElement]) bool) {
+		yield(&c.Workspaces)
+	}
+}
+
+func (c *v2NamespaceConfig) NonUpdateables() iter.Seq[diff.NonUpdateablesList[string, any]] {
+	return func(yield func(diff.NonUpdateablesList[string, any]) bool) {
+		if !yield(&c.SourceDefinitions) {
+			return
+		}
+		if !yield(&c.DestinationDefinitions) {
+			return
+		}
+		yield(&c.AccountDefinitions)
+	}
+}
+
+func (w *v2Workspace) GetUpdatedAt() time.Time { return w.UpdatedAt }
+
+func (w *v2Workspace) IsNil() bool { return w == nil }
+
+func (ws *v2Workspaces) Type() string { return "Workspaces" }
+
+func (ws *v2Workspaces) Length() int { return len(*ws) }
+
+func (ws *v2Workspaces) Reset() { *ws = make(v2Workspaces) }
+
+func (ws *v2Workspaces) List() iter.Seq2[string, diff.UpdateableElement] {
+	return func(yield func(string, diff.UpdateableElement) bool) {
+		for id, workspace := range *ws {
+			if !yield(id, workspace) {
+				return
+			}
+		}
+	}
+}
+
+func (ws *v2Workspaces) GetElementByKey(id string) (diff.UpdateableElement, bool) {
+	workspace, ok := (*ws)[id]
+	return workspace, ok
+}
+
+func (ws *v2Workspaces) SetElementByKey(id string, object diff.UpdateableElement) {
+	if *ws == nil {
+		*ws = make(v2Workspaces)
+	}
+	(*ws)[id] = object.(*v2Workspace)
+}
+
+func (d *v2SourceDefinitions) Type() string { return "SourceDefinitions" }
+
+func (d *v2SourceDefinitions) Reset() { *d = make(v2SourceDefinitions) }
+
+func (d *v2SourceDefinitions) List() iter.Seq2[string, any] { return listDefinitions(*d) }
+
+func (d *v2SourceDefinitions) SetElementByKey(name string, object any) {
+	setDefinition(d, name, object)
+}
+
+func (d *v2DestinationDefinitions) Type() string { return "DestinationDefinitions" }
+
+func (d *v2DestinationDefinitions) Reset() { *d = make(v2DestinationDefinitions) }
+
+func (d *v2DestinationDefinitions) List() iter.Seq2[string, any] { return listDefinitions(*d) }
+
+func (d *v2DestinationDefinitions) SetElementByKey(name string, object any) {
+	setDefinition(d, name, object)
+}
+
+func (d *v2AccountDefinitions) Type() string { return "AccountDefinitions" }
+
+func (d *v2AccountDefinitions) Reset() { *d = make(v2AccountDefinitions) }
+
+func (d *v2AccountDefinitions) List() iter.Seq2[string, any] { return listDefinitions(*d) }
+
+func (d *v2AccountDefinitions) SetElementByKey(name string, object any) {
+	setDefinition(d, name, object)
+}
+
+// listDefinitions adapts a catalogue to the iterator the differ replaces it through.
+func listDefinitions[M ~map[string]T, T any](definitions M) iter.Seq2[string, any] {
+	return func(yield func(string, any) bool) {
+		for name, definition := range definitions {
+			if !yield(name, definition) {
+				return
+			}
+		}
+	}
+}
+
+// setDefinition is the inverse of listDefinitions. The differ only ever hands back values it took
+// out of a catalogue of the same type, so the assertion cannot fail.
+func setDefinition[M ~map[string]T, T any](definitions *M, name string, object any) {
+	if *definitions == nil {
+		*definitions = make(M)
+	}
+	(*definitions)[name] = object.(T)
+}

--- a/backend-config/namespace_config_v2_mapper.go
+++ b/backend-config/namespace_config_v2_mapper.go
@@ -1,0 +1,28 @@
+package backendconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+var _ mapper = &stubMapper{}
+
+// stubMapper stands in until the real v2 to v1 transform lands. It produces the least a ConfigT
+// can be identified by, so that the resolver around it - the incremental merge, the memo, the
+// post-transform steps - can be exercised on its own.
+type stubMapper struct{}
+
+func (*stubMapper) Map(workspaceID string, raw json.RawMessage, _ v2Catalogues) (ConfigT, error) {
+	config := ConfigT{WorkspaceID: workspaceID}
+	if updatedAt := gjson.GetBytes(raw, "updatedAt"); updatedAt.Exists() {
+		parsed, err := time.Parse(time.RFC3339, updatedAt.Str)
+		if err != nil {
+			return ConfigT{}, fmt.Errorf("parsing updatedAt: %w", err)
+		}
+		config.UpdatedAt = parsed
+	}
+	return config, nil
+}

--- a/backend-config/namespace_config_v2_mapper.go
+++ b/backend-config/namespace_config_v2_mapper.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	"github.com/tidwall/gjson"
 )
 
 var _ mapper = &stubMapper{}
@@ -17,8 +15,8 @@ type stubMapper struct{}
 
 func (*stubMapper) Map(workspaceID string, raw json.RawMessage, _ v2Catalogues) (ConfigT, error) {
 	config := ConfigT{WorkspaceID: workspaceID}
-	if updatedAt := gjson.GetBytes(raw, "updatedAt"); updatedAt.Exists() {
-		parsed, err := time.Parse(time.RFC3339, updatedAt.Str)
+	if updatedAt := jsonparser.GetStringOrEmpty(raw, "updatedAt"); updatedAt != "" {
+		parsed, err := time.Parse(time.RFC3339, updatedAt)
 		if err != nil {
 			return ConfigT{}, fmt.Errorf("parsing updatedAt: %w", err)
 		}

--- a/backend-config/namespace_config_v2_test.go
+++ b/backend-config/namespace_config_v2_test.go
@@ -1,0 +1,502 @@
+package backendconfig
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+)
+
+func TestV2ConfigFetcher(t *testing.T) {
+	t.Run("get", func(t *testing.T) {
+		ctx := context.Background()
+
+		t.Run("the request carries secrets=embed and the updatedAfter format the gateway validates", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{
+				v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+				v2Doc{Workspaces: map[string]any{"ws-1": nil}}.json(t),
+			}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			_, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "embed", srv.lastQuery().Get("secrets"))
+			require.NotContains(t, srv.lastQuery(), "updatedAfter", "nothing has been fetched yet")
+
+			_, err = fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "embed", srv.lastQuery().Get("secrets"))
+			updatedAfter := srv.lastQuery().Get("updatedAfter")
+			require.Equal(t, "2026-07-24T17:01:55.777Z", updatedAfter)
+			_, err = time.Parse(updatedAfterTimeFormat, updatedAfter)
+			require.NoError(t, err, "the control plane validates this format strictly")
+		})
+
+		t.Run("the workspaces are mapped and stamped with the connection flags", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{
+				"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+				"ws-2": v2Workspaceof("2026-07-20T10:00:00.000Z"),
+			}}.json(t)}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Len(t, configs, 2)
+			for workspaceID, config := range configs {
+				require.Equal(t, workspaceID, config.WorkspaceID)
+				require.Equal(t, "mockCpRouterURL", config.ConnectionFlags.URL)
+				require.True(t, config.ConnectionFlags.Services["warehouse"])
+				require.True(t, config.ConnectionFlags.Services["rudderstack-processor"])
+			}
+			// the newest workspace drives the next updatedAfter
+			require.Equal(t, "2026-07-24T17:01:55.777Z", fetcher.lastUpdatedAt.Format(updatedAfterTimeFormat))
+		})
+
+		t.Run("a workspace removed on a poll where every survivor is null does not linger", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{
+				v2Doc{Workspaces: map[string]any{
+					"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+					"ws-2": v2Workspaceof("2026-07-20T10:00:00.000Z"),
+				}}.json(t),
+				// ws-2 is gone and ws-1 did not change
+				v2Doc{Workspaces: map[string]any{"ws-1": nil}}.json(t),
+			}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Len(t, configs, 2)
+
+			// a workspace the cache holds on to, standing in for any cache entry the differ does not
+			// drop: membership is read off the response, so it must not reach the result either way
+			fetcher.cache.Workspaces["ws-3"] = fetcher.cache.Workspaces["ws-2"]
+
+			configs, err = fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Len(t, configs, 1)
+			require.Contains(t, configs, "ws-1")
+			require.NotContains(t, configs, "ws-2")
+			require.NotContains(t, configs, "ws-3")
+			require.NotContains(t, fetcher.memo, "ws-2", "the memo is rebuilt from the response too")
+			require.NotContains(t, fetcher.memo, "ws-3")
+		})
+
+		t.Run("a workspace that was never seen before triggers a full fetch", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			full := v2Doc{Workspaces: map[string]any{
+				"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+				"ws-2": v2Workspaceof("2026-07-25T10:00:00.000Z"),
+			}}.json(t)
+			srv.responses = [][]byte{
+				v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+				// ws-2 arrives null without ever having been sent in full
+				v2Doc{Workspaces: map[string]any{"ws-1": nil, "ws-2": nil}}.json(t),
+				full,
+			}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			_, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err, "the failed incremental update must be retried as a full one")
+			require.Len(t, configs, 2)
+			require.Len(t, srv.requests, 3)
+			require.Empty(t, srv.requests[2].Query().Get("updatedAfter"), "the retry asks for everything")
+		})
+	})
+
+	t.Run("rejects", func(t *testing.T) {
+		ctx := context.Background()
+
+		t.Run("a response from an endpoint that is not v2", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{[]byte(`{"ws-1":{"sources":[],"updatedAt":"2026-07-24T17:01:55.777Z"}}`)}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			_, err := fetcher.Get(ctx)
+			require.ErrorContains(t, err, "unexpected config version 0")
+		})
+	})
+
+	t.Run("memo", func(t *testing.T) {
+		ctx := context.Background()
+		unchanged := map[string]any{"ws-1": nil}
+
+		for _, tc := range []struct {
+			name      string
+			second    v2Doc
+			wantCalls int
+		}{
+			{
+				name:      "hit on an unchanged workspace and an unchanged generation",
+				second:    v2Doc{Workspaces: unchanged},
+				wantCalls: 1,
+			},
+			{
+				name:      "miss on a changed workspace",
+				second:    v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-25T17:01:55.777Z")}},
+				wantCalls: 2,
+			},
+			{
+				name: "miss on a definition edit with no workspace change",
+				second: v2Doc{
+					Workspaces:        unchanged,
+					SourceDefinitions: map[string]any{"webhook": v2Definition("src-1", "2026-06-01T00:00:00.000Z")},
+				},
+				wantCalls: 2,
+			},
+			{
+				name: "miss on a definition deletion, which bumps no timestamp",
+				second: v2Doc{
+					Workspaces:             unchanged,
+					DestinationDefinitions: map[string]any{},
+				},
+				wantCalls: 2,
+			},
+			{
+				name: "miss on a definition addition",
+				second: v2Doc{
+					Workspaces: unchanged,
+					AccountDefinitions: map[string]any{
+						"ACC":   v2Definition("acc-1", "2026-01-03T00:00:00.000Z"),
+						"ACC-2": v2Definition("acc-2", "2026-01-03T00:00:00.000Z"),
+					},
+				},
+				wantCalls: 2,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				srv := &v2Server{t: t, secret: "service-secret"}
+				srv.responses = [][]byte{
+					v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+					tc.second.json(t),
+				}
+				fetcher, counting := newV2TestFetcher(t, srv)
+
+				_, err := fetcher.Get(ctx)
+				require.NoError(t, err)
+				require.Equal(t, 1, counting.calls["ws-1"])
+
+				configs, err := fetcher.Get(ctx)
+				require.NoError(t, err)
+				require.Len(t, configs, 1)
+				require.Equal(t, tc.wantCalls, counting.calls["ws-1"])
+			})
+		}
+	})
+
+	t.Run("incremental updates disabled", func(t *testing.T) {
+		// the production default: every poll asks for the whole config
+		ctx := context.Background()
+		srv := &v2Server{t: t, secret: "service-secret"}
+		srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{
+			"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+			"ws-2": v2Workspaceof("2026-07-20T10:00:00.000Z"),
+		}}.json(t)}
+		fetcher, counting := newV2TestFetcher(t, srv, func(nc *namespaceConfig) {
+			nc.incrementalConfigUpdates = false
+		})
+
+		for range 3 {
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Len(t, configs, 2)
+		}
+		require.Len(t, srv.requests, 3)
+		for i, request := range srv.requests {
+			require.Empty(t, request.Query().Get("updatedAfter"), "request %d must ask for everything", i)
+			require.Equal(t, "embed", request.Query().Get("secrets"))
+		}
+		// nothing arrives as null, so every workspace counts as changed and is transformed every time
+		require.Equal(t, 3, counting.calls["ws-1"])
+		require.Equal(t, 3, counting.calls["ws-2"])
+	})
+
+	t.Run("updatedAfter across polls", func(t *testing.T) {
+		ctx := context.Background()
+		srv := &v2Server{t: t, secret: "service-secret"}
+		srv.responses = [][]byte{
+			v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+			v2Doc{Workspaces: map[string]any{"ws-1": nil}}.json(t),
+			v2Doc{Workspaces: map[string]any{"ws-1": nil}}.json(t),
+		}
+		fetcher, _ := newV2TestFetcher(t, srv)
+
+		for range 3 {
+			_, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+		}
+		// a poll in which nothing was updated leaves updatedAfter where it was: there is no way to
+		// know the control plane's clock, so moving it forward would skip updates
+		require.Equal(t, "2026-07-24T17:01:55.777Z", srv.requests[1].Query().Get("updatedAfter"))
+		require.Equal(t, "2026-07-24T17:01:55.777Z", srv.requests[2].Query().Get("updatedAfter"))
+	})
+
+	t.Run("mixed workspaces in one poll", func(t *testing.T) {
+		ctx := context.Background()
+		firstPoll := v2Doc{Workspaces: map[string]any{
+			"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+			"ws-2": v2Workspaceof("2026-07-20T10:00:00.000Z"),
+		}}.json(t)
+		srv := &v2Server{t: t, secret: "service-secret"}
+		srv.responses = [][]byte{
+			firstPoll,
+			// ws-1 changed, ws-2 did not: the memo has to discriminate within a single poll
+			v2Doc{Workspaces: map[string]any{
+				"ws-1": v2Workspaceof("2026-07-26T17:01:55.777Z"),
+				"ws-2": nil,
+			}}.json(t),
+		}
+		fetcher, counting := newV2TestFetcher(t, srv)
+
+		_, err := fetcher.Get(ctx)
+		require.NoError(t, err)
+		configs, err := fetcher.Get(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, configs, 2)
+		require.Equal(t, 2, counting.calls["ws-1"], "the changed workspace is transformed again")
+		require.Equal(t, 1, counting.calls["ws-2"], "the unchanged one is served from the memo")
+		require.Equal(t, "2026-07-26T17:01:55.777Z", configs["ws-1"].UpdatedAt.Format(updatedAfterTimeFormat))
+		require.Equal(t, "2026-07-20T10:00:00.000Z", configs["ws-2"].UpdatedAt.Format(updatedAfterTimeFormat))
+	})
+
+	t.Run("maps the cached body on a memo miss", func(t *testing.T) {
+		// the resolver caches the raw workspace body, so a workspace that arrives as null can still be
+		// transformed when something else - here a definition edit - invalidates its memo entry
+		ctx := context.Background()
+		srv := &v2Server{t: t, secret: "service-secret"}
+		srv.responses = [][]byte{
+			v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+			v2Doc{
+				Workspaces:        map[string]any{"ws-1": nil},
+				SourceDefinitions: map[string]any{"webhook": v2Definition("src-1", "2026-06-01T00:00:00.000Z")},
+			}.json(t),
+		}
+		fetcher, counting := newV2TestFetcher(t, srv)
+
+		_, err := fetcher.Get(ctx)
+		require.NoError(t, err)
+		firstRaw := string(counting.raw["ws-1"])
+		require.Contains(t, firstRaw, `"updatedAt":"2026-07-24T17:01:55.777Z"`)
+
+		configs, err := fetcher.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 2, counting.calls["ws-1"])
+		require.Equal(t, firstRaw, string(counting.raw["ws-1"]), "the cached body, not the null that arrived")
+		require.Equal(t, "2026-07-24T17:01:55.777Z", configs["ws-1"].UpdatedAt.Format(updatedAfterTimeFormat))
+		// and it is mapped against the edited catalogue
+		require.Equal(t, "2026-06-01T00:00:00.000Z",
+			fetcher.cache.SourceDefinitions["webhook"].UpdatedAt.Format(updatedAfterTimeFormat))
+	})
+
+	t.Run("request failures", func(t *testing.T) {
+		ctx := context.Background()
+
+		t.Run("a transient failure is retried", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret", failFirst: 1}
+			srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{
+				"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+			}}.json(t)}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Len(t, configs, 1)
+			require.Len(t, srv.requests, 2, "the failed attempt and the one that succeeded")
+		})
+
+		t.Run("invalid credentials", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{
+				"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+			}}.json(t)}
+			fetcher, _ := newV2TestFetcher(t, srv, func(nc *namespaceConfig) {
+				nc.hostedServiceSecret = "wrong-secret"
+			})
+
+			configs, err := fetcher.Get(ctx)
+			require.ErrorContains(t, err, "unexpected status code: 401")
+			require.Empty(t, configs)
+		})
+	})
+
+	t.Run("config env replacement", func(t *testing.T) {
+		ctx := context.Background()
+		previous := configEnvReplacementEnabled
+		configEnvReplacementEnabled = true
+		t.Cleanup(func() { configEnvReplacementEnabled = previous })
+
+		t.Run("the payload is rewritten before it is decoded", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{
+				"ws-PLACEHOLDER": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+			}}.json(t)}
+			configEnv := &replacingConfigEnv{old: "PLACEHOLDER", new: "1"}
+			fetcher, _ := newV2TestFetcher(t, srv, func(nc *namespaceConfig) {
+				nc.configEnvHandler = configEnv
+			})
+
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 1, configEnv.calls)
+			require.Contains(t, configs, "ws-1")
+			require.NotContains(t, configs, "ws-PLACEHOLDER")
+		})
+
+		t.Run("a non 200 still surfaces, body and all", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{
+				"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z"),
+			}}.json(t)}
+			fetcher, _ := newV2TestFetcher(t, srv, func(nc *namespaceConfig) {
+				nc.configEnvHandler = &replacingConfigEnv{old: "PLACEHOLDER", new: "1"}
+				nc.hostedServiceSecret = "wrong-secret"
+			})
+
+			_, err := fetcher.Get(ctx)
+			require.ErrorContains(t, err, "unexpected status code: 401")
+			require.ErrorContains(t, err, "Unauthorized", "the body has to survive the rewrite")
+		})
+	})
+}
+
+// a v2 response, built the way the control plane serves it: definitions in full every time,
+// workspaces null unless they changed since updatedAfter.
+type v2Doc struct {
+	Version                int            `json:"version"`
+	SourceDefinitions      map[string]any `json:"sourceDefinitions"`
+	DestinationDefinitions map[string]any `json:"destinationDefinitions"`
+	AccountDefinitions     map[string]any `json:"accountDefinitions"`
+	Workspaces             map[string]any `json:"workspaces"`
+}
+
+func v2Definition(id, updatedAt string) map[string]any {
+	return map[string]any{"id": id, "updatedAt": updatedAt, "displayName": id}
+}
+
+func v2Workspaceof(updatedAt string) map[string]any {
+	return map[string]any{"updatedAt": updatedAt, "sources": map[string]any{}}
+}
+
+func (d v2Doc) json(t *testing.T) []byte {
+	t.Helper()
+	d.Version = v2ConfigVersion
+	if d.SourceDefinitions == nil {
+		d.SourceDefinitions = map[string]any{"webhook": v2Definition("src-1", "2026-01-01T00:00:00.000Z")}
+	}
+	if d.DestinationDefinitions == nil {
+		d.DestinationDefinitions = map[string]any{"WEBHOOK": v2Definition("dst-1", "2026-01-02T00:00:00.000Z")}
+	}
+	if d.AccountDefinitions == nil {
+		d.AccountDefinitions = map[string]any{"ACC": v2Definition("acc-1", "2026-01-03T00:00:00.000Z")}
+	}
+	body, err := jsonrs.Marshal(d)
+	require.NoError(t, err)
+	return body
+}
+
+// v2Server serves a canned response per poll and records what was asked of it.
+type v2Server struct {
+	t         *testing.T
+	responses [][]byte
+	requests  []*url.URL
+	secret    string
+	failFirst int // how many of the first requests to answer with a 500
+}
+
+func (s *v2Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	user, _, ok := r.BasicAuth()
+	require.True(s.t, ok)
+
+	s.requests = append(s.requests, r.URL)
+	if user != s.secret {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+		return
+	}
+	if len(s.requests) <= s.failFirst {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	i := len(s.requests) - 1
+	if i >= len(s.responses) {
+		i = len(s.responses) - 1 // keep serving the last one
+	}
+	_, _ = w.Write(s.responses[i])
+}
+
+func (s *v2Server) lastQuery() url.Values { return s.requests[len(s.requests)-1].Query() }
+
+// countingMapper records how often the transform actually ran, per workspace.
+type countingMapper struct {
+	inner mapper
+	calls map[string]int
+	raw   map[string]json.RawMessage
+}
+
+func (m *countingMapper) Map(workspaceID string, raw json.RawMessage, catalogues v2Catalogues) (ConfigT, error) {
+	if m.calls == nil {
+		m.calls, m.raw = make(map[string]int), make(map[string]json.RawMessage)
+	}
+	m.calls[workspaceID]++
+	m.raw[workspaceID] = raw
+	return m.inner.Map(workspaceID, raw, catalogues)
+}
+
+func newV2TestFetcher(t *testing.T, srv *v2Server, opts ...func(*namespaceConfig)) (*v2ConfigFetcher, *countingMapper) {
+	t.Helper()
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	conf := config.New()
+	conf.Set("CONFIG_BACKEND_URL", ts.URL)
+
+	nc := &namespaceConfig{
+		config:                   conf,
+		logger:                   logger.NOP,
+		stats:                    stats.NOP,
+		client:                   ts.Client(),
+		namespace:                "free-us-1",
+		hostedServiceSecret:      srv.secret,
+		cpRouterURL:              "mockCpRouterURL",
+		incrementalConfigUpdates: true,
+	}
+	for _, opt := range opts {
+		opt(nc)
+	}
+	require.NoError(t, nc.SetUp())
+
+	// built directly: nothing selects the v2 fetcher until the real mapper lands
+	fetcher, err := newV2ConfigFetcher(nc)
+	require.NoError(t, err)
+	counting := &countingMapper{inner: fetcher.mapper}
+	fetcher.mapper = counting
+	return fetcher, counting
+}
+
+// replacingConfigEnv stands in for the env variable injection the deployment wires in.
+type replacingConfigEnv struct {
+	old, new string
+	calls    int
+}
+
+func (c *replacingConfigEnv) ReplaceConfigWithEnvVariables(workspaceConfig []byte) []byte {
+	c.calls++
+	return bytes.ReplaceAll(workspaceConfig, []byte(c.old), []byte(c.new))
+}

--- a/backend-config/namespace_config_v2_test.go
+++ b/backend-config/namespace_config_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -305,6 +306,66 @@ func TestV2ConfigFetcher(t *testing.T) {
 			fetcher.cache.SourceDefinitions["webhook"].UpdatedAt.Format(updatedAfterTimeFormat))
 	})
 
+	t.Run("a poll that fails to map leaves updatedAfter where it was", func(t *testing.T) {
+		ctx := context.Background()
+		srv := &v2Server{t: t, secret: "service-secret"}
+		srv.responses = [][]byte{
+			v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+			v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-26T10:00:00.000Z")}}.json(t),
+			v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-26T10:00:00.000Z")}}.json(t),
+		}
+		fetcher, counting := newV2TestFetcher(t, srv)
+
+		_, err := fetcher.Get(ctx)
+		require.NoError(t, err)
+
+		// the update arrives but cannot be mapped
+		counting.err = errors.New("mapper is having a day")
+		_, err = fetcher.Get(ctx)
+		require.ErrorContains(t, err, "mapper is having a day")
+
+		// had updatedAfter moved, the control plane would answer the next poll with a null for a
+		// workspace nothing has mapped yet, and the memo would keep serving the config it replaced
+		counting.err = nil
+		configs, err := fetcher.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "2026-07-24T17:01:55.777Z", srv.requests[2].Query().Get("updatedAfter"))
+		require.Equal(t, "2026-07-26T10:00:00.000Z", configs["ws-1"].UpdatedAt.Format(updatedAfterTimeFormat))
+	})
+
+	t.Run("a response without workspaces", func(t *testing.T) {
+		ctx := context.Background()
+
+		t.Run("is not worth refetching when it already was a full response", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{v2Doc{Workspaces: map[string]any{}}.json(t)}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			_, err := fetcher.Get(ctx)
+			require.ErrorContains(t, err, "no workspaces in response")
+			require.NotErrorIs(t, err, ErrIncrementalUpdateFailed)
+			require.Len(t, srv.requests, 1, "asking again would only repeat it")
+		})
+
+		t.Run("is retried in full when a delta was asked for", func(t *testing.T) {
+			srv := &v2Server{t: t, secret: "service-secret"}
+			srv.responses = [][]byte{
+				v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+				v2Doc{Workspaces: map[string]any{}}.json(t),
+				v2Doc{Workspaces: map[string]any{"ws-1": v2Workspaceof("2026-07-24T17:01:55.777Z")}}.json(t),
+			}
+			fetcher, _ := newV2TestFetcher(t, srv)
+
+			_, err := fetcher.Get(ctx)
+			require.NoError(t, err)
+			configs, err := fetcher.Get(ctx)
+			require.NoError(t, err, "the retry asks for everything and gets it")
+			require.Len(t, configs, 1)
+			require.Len(t, srv.requests, 3)
+			require.Empty(t, srv.requests[2].Query().Get("updatedAfter"))
+		})
+	})
+
 	t.Run("request failures", func(t *testing.T) {
 		ctx := context.Background()
 
@@ -448,6 +509,7 @@ type countingMapper struct {
 	inner mapper
 	calls map[string]int
 	raw   map[string]json.RawMessage
+	err   error // when set, every mapping fails
 }
 
 func (m *countingMapper) Map(workspaceID string, raw json.RawMessage, catalogues v2Catalogues) (ConfigT, error) {
@@ -456,6 +518,9 @@ func (m *countingMapper) Map(workspaceID string, raw json.RawMessage, catalogues
 	}
 	m.calls[workspaceID]++
 	m.raw[workspaceID] = raw
+	if m.err != nil {
+		return ConfigT{}, m.err
+	}
 	return m.inner.Map(workspaceID, raw, catalogues)
 }
 

--- a/backend-config/namespace_config_v2_types.go
+++ b/backend-config/namespace_config_v2_types.go
@@ -3,14 +3,20 @@ package backendconfig
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/tidwall/gjson"
+	kitjsonparser "github.com/rudderlabs/rudder-go-kit/jsonparser"
 )
 
 // v2ConfigVersion is the version the v2 namespace config endpoint stamps on its response.
 const v2ConfigVersion = 2
+
+// Pinning the gjson backed implementation rather than taking the default one: workspace config bodies are
+// the largest JSON this process scans, and gjson goes through them at roughly twice the rate, measured from 16KB up to
+// 100MB with the field last in the object, which is where the control plane puts it.
+var jsonparser = kitjsonparser.NewWithLibrary(kitjsonparser.TidwallLib)
 
 // v2NamespaceConfig is the response of the v2 namespace config endpoint:
 //
@@ -112,11 +118,13 @@ func (w *v2Workspace) UnmarshalJSON(data []byte) error {
 	// the body is scanned for the one field we need rather than decoded: the decoder that handed
 	// us these bytes has already validated them, and decoding a single field out of a workspace
 	// this size costs more than the scan does
-	if updatedAt := gjson.GetBytes(data, "updatedAt"); updatedAt.Exists() {
-		if updatedAt.Type != gjson.String {
-			return fmt.Errorf("workspace updatedAt is a %s, expected a string", updatedAt.Type)
-		}
-		parsed, err := time.Parse(time.RFC3339, updatedAt.Str)
+	updatedAt, err := jsonparser.GetString(data, "updatedAt")
+	switch {
+	case errors.Is(err, kitjsonparser.ErrKeyNotFound): // lenient
+	case err != nil:
+		return fmt.Errorf("reading workspace updatedAt: %w", err)
+	default:
+		parsed, err := time.Parse(time.RFC3339, updatedAt)
 		if err != nil {
 			return fmt.Errorf("parsing workspace updatedAt: %w", err)
 		}

--- a/backend-config/namespace_config_v2_types.go
+++ b/backend-config/namespace_config_v2_types.go
@@ -1,0 +1,119 @@
+package backendconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// v2ConfigVersion is the version the v2 namespace config endpoint stamps on its response.
+const v2ConfigVersion = 2
+
+// v2NamespaceConfig is the response of the v2 namespace config endpoint:
+//
+//	GET /configuration/v2/namespaces/{namespace}?secrets=embed
+//
+// The definitions that v1 embeds in every source and destination are hoisted here into three
+// namespace-global catalogues sent once, and each workspace references them by name.
+type v2NamespaceConfig struct {
+	Version int `json:"version"`
+	v2Catalogues
+	Workspaces map[string]*v2Workspace `json:"workspaces"`
+}
+
+// v2Catalogues are the namespace-global definition catalogues, keyed by definition name.
+//
+// An entry is its v1 definition plus UpdatedAt, which the v1 types do not carry and which feeds
+// the generation key of the transform memo. Whatever else is on the wire (configSchema, uiConfig,
+// responseRules, ...) stays unparsed: a v1 ConfigT has nowhere to put it, so it would be decoded
+// and held on every poll without ever reaching a consumer.
+type v2Catalogues struct {
+	SourceDefinitions      map[string]v2SourceDefinition      `json:"sourceDefinitions"`
+	DestinationDefinitions map[string]v2DestinationDefinition `json:"destinationDefinitions"`
+	AccountDefinitions     map[string]v2AccountDefinition     `json:"accountDefinitions"`
+}
+
+// v2SourceDefinition is an entry of the sourceDefinitions catalogue.
+//
+// Note the embedded Name is not on the wire: source and destination definitions are named by their
+// catalogue key alone. Reach for toV1 rather than the embedded value, or the name is empty.
+type v2SourceDefinition struct {
+	SourceDefinitionT
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// toV1 returns the definition as v1 spells it, named after the key it is catalogued under.
+func (d v2SourceDefinition) toV1(name string) SourceDefinitionT {
+	definition := d.SourceDefinitionT
+	definition.Name = name
+	return definition
+}
+
+// v2DestinationDefinition is an entry of the destinationDefinitions catalogue.
+type v2DestinationDefinition struct {
+	DestinationDefinitionT
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// toV1 returns the definition as v1 spells it, named after the key it is catalogued under.
+func (d v2DestinationDefinition) toV1(name string) DestinationDefinitionT {
+	definition := d.DestinationDefinitionT
+	definition.Name = name
+	return definition
+}
+
+// v2AccountDefinition is an entry of the accountDefinitions catalogue. Unlike the other two,
+// account definitions do carry their own name, which the control plane keeps equal to the key.
+type v2AccountDefinition struct {
+	AccountDefinition
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// toV1 returns the definition as v1 spells it, named after the key it is catalogued under.
+func (d v2AccountDefinition) toV1(name string) AccountDefinition {
+	definition := d.AccountDefinition
+	definition.Name = name
+	return definition
+}
+
+// v2Workspace is one workspace of the response.
+//
+// The workspace body is deliberately left untyped: the resolver caches the raw bytes and hands
+// them to the mapper, so the full workspace schema belongs to the mapper alone. Only updatedAt is
+// read here, and it is load bearing - it drives the updatedAfter of the next poll and the memo
+// that lets an unchanged workspace skip the transform.
+type v2Workspace struct {
+	UpdatedAt time.Time
+	Raw       json.RawMessage
+}
+
+func (w *v2Workspace) UnmarshalJSON(data []byte) error {
+	// the body is scanned for the one field we need rather than decoded: the decoder that handed
+	// us these bytes has already validated them, and decoding a single field out of a workspace
+	// this size costs more than the scan does
+	if updatedAt := gjson.GetBytes(data, "updatedAt"); updatedAt.Exists() {
+		if updatedAt.Type != gjson.String {
+			return fmt.Errorf("workspace updatedAt is a %s, expected a string", updatedAt.Type)
+		}
+		parsed, err := time.Parse(time.RFC3339, updatedAt.Str)
+		if err != nil {
+			return fmt.Errorf("parsing workspace updatedAt: %w", err)
+		}
+		w.UpdatedAt = parsed
+	}
+	// sonnet, the default jsonrs implementation, hands back a slice of the response buffer rather
+	// than a copy, as does std: a cached workspace would otherwise pin the whole payload for as
+	// long as it is cached, and change under us if that buffer is ever reused
+	w.Raw = bytes.Clone(data)
+	return nil
+}
+
+// mapper joins one workspace's raw v2 blob with the namespace-global catalogues to produce a v1
+// ConfigT. The post-transform steps (ApplyReplaySources, processAccountAssociations,
+// ProcessDestinationsInSources) stay with the caller.
+type mapper interface {
+	Map(workspaceID string, raw json.RawMessage, catalogues v2Catalogues) (ConfigT, error)
+}

--- a/backend-config/namespace_config_v2_types.go
+++ b/backend-config/namespace_config_v2_types.go
@@ -21,8 +21,12 @@ const v2ConfigVersion = 2
 type v2NamespaceConfig struct {
 	Version int `json:"version"`
 	v2Catalogues
-	Workspaces map[string]*v2Workspace `json:"workspaces"`
+	Workspaces v2Workspaces `json:"workspaces"`
 }
+
+// v2Workspaces is the only updateable list of the response: a workspace that did not change since
+// updatedAfter arrives as null, and the key set is the namespace's membership.
+type v2Workspaces map[string]*v2Workspace
 
 // v2Catalogues are the namespace-global definition catalogues, keyed by definition name.
 //
@@ -31,10 +35,24 @@ type v2NamespaceConfig struct {
 // responseRules, ...) stays unparsed: a v1 ConfigT has nowhere to put it, so it would be decoded
 // and held on every poll without ever reaching a consumer.
 type v2Catalogues struct {
-	SourceDefinitions      map[string]v2SourceDefinition      `json:"sourceDefinitions"`
-	DestinationDefinitions map[string]v2DestinationDefinition `json:"destinationDefinitions"`
-	AccountDefinitions     map[string]v2AccountDefinition     `json:"accountDefinitions"`
+	SourceDefinitions      v2SourceDefinitions      `json:"sourceDefinitions"`
+	DestinationDefinitions v2DestinationDefinitions `json:"destinationDefinitions"`
+	AccountDefinitions     v2AccountDefinitions     `json:"accountDefinitions"`
 }
+
+type (
+	v2SourceDefinitions      map[string]v2SourceDefinition
+	v2DestinationDefinitions map[string]v2DestinationDefinition
+	v2AccountDefinitions     map[string]v2AccountDefinition
+)
+
+// v2DefinitionMeta is what every catalogue entry adds to its v1 definition: when it last changed,
+// which the v1 types do not carry and the generation key is folded from.
+type v2DefinitionMeta struct {
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (m v2DefinitionMeta) updatedAt() time.Time { return m.UpdatedAt }
 
 // v2SourceDefinition is an entry of the sourceDefinitions catalogue.
 //
@@ -42,7 +60,7 @@ type v2Catalogues struct {
 // catalogue key alone. Reach for toV1 rather than the embedded value, or the name is empty.
 type v2SourceDefinition struct {
 	SourceDefinitionT
-	UpdatedAt time.Time `json:"updatedAt"`
+	v2DefinitionMeta
 }
 
 // toV1 returns the definition as v1 spells it, named after the key it is catalogued under.
@@ -55,7 +73,7 @@ func (d v2SourceDefinition) toV1(name string) SourceDefinitionT {
 // v2DestinationDefinition is an entry of the destinationDefinitions catalogue.
 type v2DestinationDefinition struct {
 	DestinationDefinitionT
-	UpdatedAt time.Time `json:"updatedAt"`
+	v2DefinitionMeta
 }
 
 // toV1 returns the definition as v1 spells it, named after the key it is catalogued under.
@@ -69,7 +87,7 @@ func (d v2DestinationDefinition) toV1(name string) DestinationDefinitionT {
 // account definitions do carry their own name, which the control plane keeps equal to the key.
 type v2AccountDefinition struct {
 	AccountDefinition
-	UpdatedAt time.Time `json:"updatedAt"`
+	v2DefinitionMeta
 }
 
 // toV1 returns the definition as v1 spells it, named after the key it is catalogued under.

--- a/backend-config/namespace_config_v2_types_test.go
+++ b/backend-config/namespace_config_v2_types_test.go
@@ -1,0 +1,181 @@
+package backendconfig
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+)
+
+const v2SamplePayload = `{
+	"version": 2,
+	"sourceDefinitions": {
+		"webhook": {
+			"id": "1wIhTgHIVDRoJXpGvyLmnGXjHl0",
+			"category": "webhook",
+			"type": "cloud",
+			"options": {"hydration": {"enabled": true}, "sdkExecutionEnvironment": "server"},
+			"config": null,
+			"createdAt": "2020-12-07T14:20:58.237Z",
+			"updatedAt": "2026-08-06T05:34:18.760Z"
+		},
+		"snowflake": {
+			"id": "1lKfm47IlzXQNXD3C3pk6mZtb1S",
+			"category": "warehouse",
+			"type": "warehouse",
+			"options": null,
+			"updatedAt": "2026-08-01T05:34:18.760Z"
+		}
+	},
+	"destinationDefinitions": {
+		"WEBHOOK": {
+			"id": "1aIXqM806xAVm7BwUXYh6IeM7uP",
+			"displayName": "Webhook",
+			"config": {"transformAtV1": "processor", "secretKeys": ["apiKey"]},
+			"responseRules": null,
+			"category": null,
+			"updatedAt": "2026-06-17T11:23:34.585Z"
+		}
+	},
+	"accountDefinitions": {
+		"DESTINATION_SALESFORCE_OAUTH": {
+			"name": "DESTINATION_SALESFORCE_OAUTH",
+			"type": "salesforce",
+			"category": "destination",
+			"authenticationType": "oauth",
+			"config": {"refreshOAuthToken": true},
+			"updatedAt": "2026-03-26T03:15:41.921Z"
+		}
+	},
+	"workspaces": {
+		"workspace-1": {
+			"sources": {"source-1": {"name": "My Source", "sourceDefinitionName": "webhook"}},
+			"destinations": {},
+			"connections": {},
+			"updatedAt": "2026-07-24T17:01:55.777Z"
+		},
+		"workspace-2": null
+	}
+}`
+
+func TestV2NamespaceConfigUnmarshal(t *testing.T) {
+	var conf v2NamespaceConfig
+	require.NoError(t, jsonrs.Unmarshal([]byte(v2SamplePayload), &conf))
+	require.Equal(t, v2ConfigVersion, conf.Version)
+
+	t.Run("catalogues are keyed by definition name", func(t *testing.T) {
+		require.Len(t, conf.SourceDefinitions, 2)
+		require.Len(t, conf.DestinationDefinitions, 1)
+		require.Len(t, conf.AccountDefinitions, 1)
+
+		webhook, ok := conf.SourceDefinitions["webhook"]
+		require.True(t, ok)
+		require.Equal(t, "1wIhTgHIVDRoJXpGvyLmnGXjHl0", webhook.ID)
+		require.Equal(t, "webhook", webhook.Category)
+		require.Equal(t, "cloud", webhook.Type)
+		require.True(t, webhook.Options.Hydration.Enabled)
+		require.Equal(t, "2026-08-06T05:34:18.760Z", webhook.UpdatedAt.Format(updatedAfterTimeFormat))
+
+		// a null options object must not fail the whole catalogue
+		require.False(t, conf.SourceDefinitions["snowflake"].Options.Hydration.Enabled)
+
+		dest, ok := conf.DestinationDefinitions["WEBHOOK"]
+		require.True(t, ok)
+		require.Equal(t, "Webhook", dest.DisplayName)
+		require.Equal(t, "processor", dest.Config["transformAtV1"])
+
+		account, ok := conf.AccountDefinitions["DESTINATION_SALESFORCE_OAUTH"]
+		require.True(t, ok)
+		require.Equal(t, "oauth", account.AuthenticationType)
+	})
+
+	t.Run("source and destination definitions are named by their catalogue key alone", func(t *testing.T) {
+		source := conf.SourceDefinitions["webhook"]
+		require.Empty(t, source.Name, "no name on the wire")
+		require.Equal(t, SourceDefinitionT{
+			ID:       "1wIhTgHIVDRoJXpGvyLmnGXjHl0",
+			Name:     "webhook",
+			Category: "webhook",
+			Type:     "cloud",
+			Options:  source.Options,
+		}, source.toV1("webhook"))
+
+		destination := conf.DestinationDefinitions["WEBHOOK"]
+		require.Empty(t, destination.Name, "no name on the wire")
+		require.Equal(t, DestinationDefinitionT{
+			ID:          "1aIXqM806xAVm7BwUXYh6IeM7uP",
+			Name:        "WEBHOOK",
+			DisplayName: "Webhook",
+			Config:      destination.Config,
+		}, destination.toV1("WEBHOOK"))
+
+		// account definitions do carry a name, and the key stays authoritative
+		account := conf.AccountDefinitions["DESTINATION_SALESFORCE_OAUTH"]
+		require.Equal(t, "DESTINATION_SALESFORCE_OAUTH", account.Name)
+		require.Equal(t, AccountDefinition{
+			Name:               "DESTINATION_SALESFORCE_OAUTH",
+			AuthenticationType: "oauth",
+			Config:             account.Config,
+		}, account.toV1("DESTINATION_SALESFORCE_OAUTH"))
+	})
+
+	t.Run("workspace keeps its raw body and its updatedAt", func(t *testing.T) {
+		ws := conf.Workspaces["workspace-1"]
+		require.NotNil(t, ws)
+		require.Equal(t, "2026-07-24T17:01:55.777Z", ws.UpdatedAt.Format(updatedAfterTimeFormat))
+
+		// the body stays untyped: the mapper, not the resolver, owns the workspace schema
+		var body struct {
+			Sources map[string]struct {
+				Name                 string `json:"name"`
+				SourceDefinitionName string `json:"sourceDefinitionName"`
+			} `json:"sources"`
+		}
+		require.NoError(t, jsonrs.Unmarshal(ws.Raw, &body))
+		require.Equal(t, "My Source", body.Sources["source-1"].Name)
+		require.Equal(t, "webhook", body.Sources["source-1"].SourceDefinitionName)
+	})
+
+	t.Run("a workspace that was not updated arrives as null", func(t *testing.T) {
+		ws, ok := conf.Workspaces["workspace-2"]
+		require.True(t, ok, "the key must survive: it is the membership signal")
+		require.Nil(t, ws)
+	})
+
+	t.Run("the raw body outlives the buffer the decoder was given", func(t *testing.T) {
+		payload := []byte(`{"workspaces":{"workspace-1":{"updatedAt":"2026-07-24T17:01:55.777Z","sources":{}}}}`)
+		var conf v2NamespaceConfig
+		require.NoError(t, jsonrs.Unmarshal(payload, &conf))
+
+		raw := conf.Workspaces["workspace-1"].Raw
+		for i := range payload { // scribble over it: std and sonnet slice rather than copy
+			payload[i] = 'x'
+		}
+		require.Contains(t, string(raw), `"updatedAt":"2026-07-24T17:01:55.777Z"`)
+	})
+
+	t.Run("updatedAt", func(t *testing.T) {
+		t.Run("missing leaves the zero time, the resolver decides what to do about it", func(t *testing.T) {
+			var conf v2NamespaceConfig
+			require.NoError(t, jsonrs.Unmarshal([]byte(`{"workspaces":{"workspace-1":{"sources":{}}}}`), &conf))
+			require.Equal(t, time.Time{}, conf.Workspaces["workspace-1"].UpdatedAt)
+			require.NotEmpty(t, conf.Workspaces["workspace-1"].Raw)
+		})
+
+		for _, tc := range []struct {
+			name, updatedAt, wantErr string
+		}{
+			{"not a string", `1784909557360`, "expected a string"},
+			{"not a timestamp", `"yesterday"`, "parsing workspace updatedAt"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				payload := fmt.Sprintf(`{"workspaces":{"workspace-1":{"updatedAt":%s}}}`, tc.updatedAt)
+				var conf v2NamespaceConfig
+				require.ErrorContains(t, jsonrs.Unmarshal([]byte(payload), &conf), tc.wantErr)
+			})
+		}
+	})
+}

--- a/backend-config/namespace_config_v2_types_test.go
+++ b/backend-config/namespace_config_v2_types_test.go
@@ -168,7 +168,7 @@ func TestV2NamespaceConfigUnmarshal(t *testing.T) {
 		for _, tc := range []struct {
 			name, updatedAt, wantErr string
 		}{
-			{"not a string", `1784909557360`, "expected a string"},
+			{"not a string", `1784909557360`, "not of expected type"},
 			{"not a timestamp", `"yesterday"`, "parsing workspace updatedAt"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/backend-config/replay_types.go
+++ b/backend-config/replay_types.go
@@ -1,7 +1,6 @@
 package backendconfig
 
 import (
-	"github.com/grafana/jsonparser"
 	"github.com/samber/lo"
 )
 
@@ -26,8 +25,11 @@ func (c *ConfigT) ApplyReplaySources() {
 			newSource.ID = id
 			newSource.OriginalID = s.ID
 			newSource.WriteKey = id
-			newSource.Config = jsonparser.Delete(s.Config, "eventUpload") // no event uploads for replay sources for now
-			newSource.Destinations = nil                                  // destinations are added later
+			// no event uploads for replay sources
+			if config, err := jsonparser.DeleteKey(s.Config, "eventUpload"); err == nil { // the only error here is an empty config, which leaves the copy as it is
+				newSource.Config = config
+			}
+			newSource.Destinations = nil // destinations are added later
 			return &newSource
 		}), []*SourceT{nil})
 		// add destinations to sources. The instance to copy depends on the source it is being

--- a/backend-config/replay_types_test.go
+++ b/backend-config/replay_types_test.go
@@ -62,11 +62,45 @@ func TestApplyReplayConfig(t *testing.T) {
 		require.Equal(t, "s-1", c.Sources[1].OriginalID)
 		require.Equal(t, "er-s-1", c.Sources[1].WriteKey)
 		require.JSONEq(t, "{}", string(c.Sources[1].Config))
+		require.JSONEq(t, `{"eventUpload": true}`, string(c.Sources[0].Config),
+			"the replay source is a copy: dropping eventUpload must not touch the original")
 		require.Len(t, c.Sources[1].Destinations, 1)
 		require.Equal(t, "er-d-1", c.Sources[1].Destinations[0].ID)
 		require.Equal(t, "d-1", c.Sources[1].Destinations[0].OriginalID)
 		require.Equal(t, true, c.Sources[1].Destinations[0].IsProcessorEnabled)
 		require.Equal(t, "rev-1", c.Sources[1].Destinations[0].RevisionID)
+	})
+
+	t.Run("Source configs the key cannot be dropped from", func(t *testing.T) {
+		for _, tc := range []struct {
+			name, config, want string
+		}{
+			{"without the key", `{"foo": "bar"}`, `{"foo": "bar"}`},
+			{"empty object", `{}`, `{}`},
+			{"empty", ``, ``},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				c := &ConfigT{
+					Sources: []SourceT{{
+						ID:           "s-1",
+						Config:       json.RawMessage(tc.config),
+						Destinations: []DestinationT{{ID: "d-1"}},
+					}},
+					EventReplays: map[string]EventReplayConfig{
+						"er-1": {
+							Sources:      map[string]EventReplaySource{"er-s-1": {OriginalSourceID: "s-1"}},
+							Destinations: map[string]EventReplayDestination{"er-d-1": {OriginalDestinationID: "d-1"}},
+							Connections:  []EventReplayConnection{{SourceID: "er-s-1", DestinationID: "er-d-1"}},
+						},
+					},
+				}
+				c.ApplyReplaySources()
+
+				require.Len(t, c.Sources, 2)
+				require.Equal(t, "er-s-1", c.Sources[1].ID)
+				require.Equal(t, tc.want, string(c.Sources[1].Config))
+			})
+		}
 	})
 
 	t.Run("Invalid Replay Config", func(t *testing.T) {

--- a/backend-config/single_workspace.go
+++ b/backend-config/single_workspace.go
@@ -29,7 +29,6 @@ type singleWorkspaceConfig struct {
 	configBackendURL *url.URL
 	configJSONPath   string
 	configEnvHandler types.ConfigEnvI
-	region           string
 
 	workspaceIDOnce sync.Once
 	workspaceID     string
@@ -180,11 +179,6 @@ func (wc *singleWorkspaceConfig) makeHTTPRequest(ctx context.Context, url string
 
 	req.SetBasicAuth(wc.token, "")
 	req.Header.Set("Content-Type", "application/json")
-	if wc.region != "" {
-		q := req.URL.Query()
-		q.Add("region", wc.region)
-		req.URL.RawQuery = q.Encode()
-	}
 
 	defer wc.httpCallsStat.Increment()
 

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/rudderlabs/clickhouse-go/v2 v2.0.0
 	github.com/rudderlabs/compose-test v0.1.5
 	github.com/rudderlabs/keydb v1.4.1
+	github.com/rudderlabs/rudder-cp-sdk v1.4.1
 	github.com/rudderlabs/rudder-go-kit v0.78.2
 	github.com/rudderlabs/rudder-observability-kit v0.0.7
 	github.com/rudderlabs/rudder-schemas v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1133,6 +1133,8 @@ github.com/rudderlabs/keydb v1.4.1 h1:siT3oHhZ4OLKUam6j7Y9mwMVWJzn0pQqggjHMSM7Oo
 github.com/rudderlabs/keydb v1.4.1/go.mod h1:umU+ZD3zTXzhBjBvMHpg96D3WIDocxzVLdV+Mj8b3pw=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
+github.com/rudderlabs/rudder-cp-sdk v1.4.1 h1:Vd6b/l+3FRiONAIk5SYBChlEM9G4nOuT2zAS7hUq9ng=
+github.com/rudderlabs/rudder-cp-sdk v1.4.1/go.mod h1:gAYkw7S2FIRkfKWA2to8emnJaB4RXbl+8VGRqtHq8N8=
 github.com/rudderlabs/rudder-go-kit v0.78.2 h1:Q4t6gR9GgF3yuxHOR2BQ9k/IGA9pDAaMoXR3FjpYpRw=
 github.com/rudderlabs/rudder-go-kit v0.78.2/go.mod h1:sS1/RuRn9EtZb/o64l2VbN+4GDeRLG15e+Bj86xxTEY=
 github.com/rudderlabs/rudder-observability-kit v0.0.7 h1:vnIkOpcF7GRXytytls7ISfEJLNA14YE9qcoWvv5OGCo=


### PR DESCRIPTION
# Description

The first of three rudder-server PRs moving namespace config fetching to the control plane's v2
endpoint ([LLD](https://app.notion.com/p/rudderstacks/LLD-v2-namespace-config-in-rudder-server-3b9f2b415dd080d09ff5dbbef73ae407)).
It covers everything between the wire and `ConfigT` **except the transformation itself**: client, incremental merge, generation memoization, with a stub mapper standing in so the resolver can be reviewed and tested on its own.

**The v2 path cannot be enabled yet.** With the stub mapper every workspace resolves to an empty `ConfigT`, which downstream reads as "every source disappeared" rather than as a failure, so there is no flag to flip until the mapper lands. v1 is untouched and remains the only fetcher `SetUp` builds.

## Other changes

- go version bumped to 1.26.6
- The `region` query param is no longer sent by any fetcher, v1 and single-workspace included (dead feature)

## Linear Ticket

resolves PIPE-3278

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
