### PR TITLE
feat(processor): report duplicate events as dedup/filtered metrics

### DIFF
--- a/integration_test/reporting_dropped_events/reporting_dropped_events_test.go
+++ b/integration_test/reporting_dropped_events/reporting_dropped_events_test.go
@@ -458,6 +458,84 @@ func TestReportingDroppedEvents(t *testing.T) {
 		})
 	})
 
+	t.Run("Events dropped in dedup stage", func(t *testing.T) {
+		config.Reset()
+		defer config.Reset()
+
+		bcserver := backendconfigtest.NewBuilder().
+			WithWorkspaceConfig(
+				backendconfigtest.NewConfigBuilder().
+					WithSource(
+						backendconfigtest.NewSourceBuilder().
+							WithID("source-1").
+							WithWriteKey("writekey-1").
+							Build()).
+					Build()).
+			Build()
+		defer bcserver.Close()
+
+		trServer := transformertest.NewBuilder().Build()
+		defer trServer.Close()
+
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := postgres.Setup(pool, t)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		wg, ctx := errgroup.WithContext(ctx)
+		gwPort, err := kithelper.GetFreePort()
+		require.NoError(t, err)
+		// the dedup badger db lives under RUDDER_TMPDIR: keep it isolated and cleaned up, but
+		// short enough for the admin unix socket path that also lives there (t.TempDir() is too long)
+		dedupTmpDir, err := os.MkdirTemp("", "dedup")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(dedupTmpDir) })
+		wg.Go(func() error {
+			err := runRudderServer(ctx, cancel, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir(), map[string]any{
+				"Dedup.enableDedup":              true,
+				"RUDDER_TMPDIR":                  dedupTmpDir,
+				"Reporting.dedupMetrics.enabled": true,
+			})
+			if err != nil {
+				t.Logf("rudder-server exited with error: %v", err)
+			}
+			return err
+		})
+		url := fmt.Sprintf("http://localhost:%d", gwPort)
+		health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+		// 1 original + 2 duplicates, all carrying the same messageId
+		err = sendEventsWithMessageID(3, "message-id-1", "identify", "writekey-1", url)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			var jobsCount int
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+			t.Logf("gw processedJobCount: %d", jobsCount)
+			return jobsCount == 3
+		}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+		require.Eventually(t, func() bool {
+			var dedupCount, matchingDedupCount sql.NullInt64
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = '' AND pu = 'dedup'").Scan(&dedupCount))
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = '' AND pu = 'dedup' and status = 'filtered' and status_code = 298 and in_pu = '' and terminal_state = false and initial_state = false and error_type = ''").Scan(&matchingDedupCount))
+			t.Logf("dedup filtered count: %d (matching: %d)", dedupCount.Int64, matchingDedupCount.Int64)
+			logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+			return dedupCount.Int64 == 2 && matchingDedupCount.Int64 == 2
+		}, 10*time.Second, 1*time.Second, "both duplicates should be filtered in dedup stage")
+
+		require.Eventually(t, func() bool {
+			var gatewayCount sql.NullInt64
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = '' AND pu = 'gateway'").Scan(&gatewayCount))
+			t.Logf("gateway count: %d", gatewayCount.Int64)
+			return gatewayCount.Int64 == 1
+		}, 10*time.Second, 1*time.Second, "only the surviving event should be counted in the gateway stage")
+
+		cancel()
+		_ = wg.Wait()
+	})
+
 	t.Run("Events dropped in batch router delivery stage", func(t *testing.T) {
 		t.Run("destination id included in BatchRouter.toAbortDestinationIDs", func(t *testing.T) {
 			config.Reset()
@@ -543,7 +621,7 @@ func TestReportingDroppedEvents(t *testing.T) {
 	})
 }
 
-func runRudderServer(ctx context.Context, cancel context.CancelFunc, port int, postgresContainer *postgres.Resource, cbURL, transformerURL, tmpDir string) (err error) {
+func runRudderServer(ctx context.Context, cancel context.CancelFunc, port int, postgresContainer *postgres.Resource, cbURL, transformerURL, tmpDir string, configOverrides ...map[string]any) (err error) {
 	config.Set("CONFIG_BACKEND_URL", cbURL)
 	config.Set("WORKSPACE_TOKEN", "token")
 	config.Set("DB.host", postgresContainer.Host)
@@ -569,6 +647,12 @@ func runRudderServer(ctx context.Context, cancel context.CancelFunc, port int, p
 	config.Set("recovery.enabled", false)
 	config.Set("Profiler.Enabled", false)
 	config.Set("Gateway.enableSuppressUserFeature", false)
+
+	for _, overrides := range configOverrides {
+		for key, value := range overrides {
+			config.Set(key, value)
+		}
+	}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -603,6 +687,51 @@ func sendEvents(num int, eventType, writeKey, url string) error { // nolint:unpa
 			"timestamp": "2020-02-02T00:23:09.544Z"
 			}]}`,
 			rand.String(10),
+			eventType)
+		req, err := http.NewRequest("POST", url+"/v1/batch", bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		req.SetBasicAuth(writeKey, "password")
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("failed to send event to rudder server, status code: %d: %s", resp.StatusCode, string(b))
+		}
+		func() { kithttputil.CloseResponse(resp) }()
+	}
+
+	return nil
+}
+
+// sendEventsWithMessageID sends num events all carrying the same messageId, so that every
+// event after the first one is a duplicate as far as the processor's dedup stage is concerned.
+func sendEventsWithMessageID(num int, messageID, eventType, writeKey, url string) error { // nolint:unparam
+	for range num {
+		payload := fmt.Appendf(nil, `{"batch": [{
+			"userId": %[1]q,
+			"messageId": %[2]q,
+			"type": %[3]q,
+			"context":
+			{
+				"traits":
+				{
+					"trait1": "new-val"
+				},
+				"ip": "14.5.67.21",
+				"library":
+				{
+					"name": "http"
+				}
+			},
+			"timestamp": "2020-02-02T00:23:09.544Z"
+			}]}`,
+			rand.String(10),
+			messageID,
 			eventType)
 		req, err := http.NewRequest("POST", url+"/v1/batch", bytes.NewReader(payload))
 		if err != nil {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -205,6 +205,7 @@ type Handle struct {
 		userTransformationMirroringBlockedIDs     config.ValueLoader[[]string]
 		storeSamplerEnabled                       config.ValueLoader[bool]
 		forkRsourcesTrackedJobs                   bool
+		dedupMetricsEnabled                       config.ValueLoader[bool]
 	}
 
 	drainConfig struct {
@@ -851,6 +852,7 @@ func (proc *Handle) loadReloadableConfig(defaultPayloadLimit int64, defaultMaxEv
 	proc.config.mirrorFilterCacheTTL = proc.conf.GetDurationVar(3, time.Hour, "Processor.userTransformationMirroring.filterCacheTTL")
 	proc.config.userTransformationMirroringBlockedIDs = proc.conf.GetReloadableStringSliceVar(nil, "Processor.userTransformationMirroring.blockedTransformationIDs")
 	proc.config.storeSamplerEnabled = proc.conf.GetReloadableBoolVar(false, "Processor.storeSamplerEnabled")
+	proc.config.dedupMetricsEnabled = proc.conf.GetReloadableBoolVar(false, "Reporting.dedupMetrics.enabled")
 }
 
 type connection struct {
@@ -1758,6 +1760,7 @@ type preTransformationMessage struct {
 	enricherStatusDetailsMap      map[string]map[string]*reportingtypes.StatusDetail
 	botManagementStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
 	eventBlockingStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
+	dedupStatusDetailsMap         map[string]map[string]*reportingtypes.StatusDetail
 	destFilterStatusDetailMap     map[string]map[string]*reportingtypes.StatusDetail
 	reportMetrics                 []*reportingtypes.PUReportedMetric
 	totalEvents                   int
@@ -1816,6 +1819,7 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob, delay time
 	enricherStatusDetailsMap := make(map[string]map[string]*reportingtypes.StatusDetail)
 	botManagementStatusDetailsMap := make(map[string]map[string]*reportingtypes.StatusDetail)
 	eventBlockingStatusDetailsMap := make(map[string]map[string]*reportingtypes.StatusDetail)
+	dedupStatusDetailsMap := make(map[string]map[string]*reportingtypes.StatusDetail)
 	// map of jobID to destinationID: for messages that needs to be delivered to a specific destinations only
 	jobIDToSpecificDestMapOnly := make(map[int64]string)
 
@@ -2066,6 +2070,28 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob, delay time
 			if !allowedBatchKeys[event.dedupKey] {
 				proc.logger.Debugn("Dropping event with duplicate key %s", logger.NewStringField("key", event.dedupKey.Key))
 				sourceDupStats[dupStatKey{sourceID: event.eventParams.SourceId}] += 1
+
+				// REPORTING - DEDUP metrics - START
+				if proc.isReportingEnabled() && proc.config.dedupMetricsEnabled.Load() {
+					reportingEvent.StatusCode = reportingtypes.FilterEventCode
+					proc.updateMetricMaps(
+						nil,
+						nil,
+						connectionDetailsMap,
+						dedupStatusDetailsMap,
+						reportingEvent,
+						jobsdb.Filtered.State,
+						reportingtypes.DEDUP,
+						func() json.RawMessage {
+							return nil
+						},
+						nil,
+					)
+					// reset status code to 0 because transformerEvent is reused for other metrics
+					reportingEvent.StatusCode = 0
+				}
+				// REPORTING - DEDUP metrics - END
+
 				continue
 			}
 			dedupKeys[event.dedupKey.Key] = struct{}{}
@@ -2236,6 +2262,7 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob, delay time
 		enricherStatusDetailsMap:      enricherStatusDetailsMap,
 		botManagementStatusDetailsMap: botManagementStatusDetailsMap,
 		eventBlockingStatusDetailsMap: eventBlockingStatusDetailsMap,
+		dedupStatusDetailsMap:         dedupStatusDetailsMap,
 		reportMetrics:                 reportMetrics,
 		destFilterStatusDetailMap:     destFilterStatusDetailMap,
 		totalEvents:                   totalEvents,
@@ -2296,6 +2323,7 @@ func (proc *Handle) pretransformStage(partition string, preTrans *preTransformat
 		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.destFilterStatusDetailMap)
 		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.botManagementStatusDetailsMap)
 		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.eventBlockingStatusDetailsMap)
+		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.dedupStatusDetailsMap)
 		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.enricherStatusDetailsMap)
 
 		for k, cd := range preTrans.connectionDetailsMap {
@@ -2311,6 +2339,14 @@ func (proc *Handle) pretransformStage(partition string, preTrans *preTransformat
 				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
 					ConnectionDetails: *cd,
 					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.EVENT_BLOCKING, false, false),
+					StatusDetail:      sd,
+				})
+			}
+
+			for _, sd := range preTrans.dedupStatusDetailsMap[k] {
+				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
+					ConnectionDetails: *cd,
+					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.DEDUP, false, false),
 					StatusDetail:      sd,
 				})
 			}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -205,7 +205,7 @@ type Handle struct {
 		userTransformationMirroringBlockedIDs     config.ValueLoader[[]string]
 		storeSamplerEnabled                       config.ValueLoader[bool]
 		forkRsourcesTrackedJobs                   bool
-		dedupMetricsEnabled                       config.ValueLoader[bool]
+		reportingDedupMetricsEnabled              config.ValueLoader[bool]
 	}
 
 	drainConfig struct {
@@ -852,7 +852,7 @@ func (proc *Handle) loadReloadableConfig(defaultPayloadLimit int64, defaultMaxEv
 	proc.config.mirrorFilterCacheTTL = proc.conf.GetDurationVar(3, time.Hour, "Processor.userTransformationMirroring.filterCacheTTL")
 	proc.config.userTransformationMirroringBlockedIDs = proc.conf.GetReloadableStringSliceVar(nil, "Processor.userTransformationMirroring.blockedTransformationIDs")
 	proc.config.storeSamplerEnabled = proc.conf.GetReloadableBoolVar(false, "Processor.storeSamplerEnabled")
-	proc.config.dedupMetricsEnabled = proc.conf.GetReloadableBoolVar(false, "Reporting.dedupMetrics.enabled")
+	proc.config.reportingDedupMetricsEnabled = proc.conf.GetReloadableBoolVar(false, "Reporting.dedupMetrics.enabled")
 }
 
 type connection struct {
@@ -2072,7 +2072,7 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob, delay time
 				sourceDupStats[dupStatKey{sourceID: event.eventParams.SourceId}] += 1
 
 				// REPORTING - DEDUP metrics - START
-				if proc.isReportingEnabled() && proc.config.dedupMetricsEnabled.Load() {
+				if proc.isReportingEnabled() && proc.config.reportingDedupMetricsEnabled.Load() {
 					reportingEvent.StatusCode = reportingtypes.FilterEventCode
 					proc.updateMetricMaps(
 						nil,

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -5806,3 +5806,189 @@ func TestStoreMessageMerge(t *testing.T) {
 		start:          time.UnixMicro(99999999),
 	})
 }
+
+// TestDedupReporting pins the dedup report-row emission added at the duplicate-drop
+// point in preprocessStage: a single DEDUP/filtered row per drop, gated by
+// proc.isReportingEnabled() && proc.config.dedupMetricsEnabled, with no gateway row
+// for the dropped twin and no change to the unconditional sourceDupStats counter.
+func TestDedupReporting(t *testing.T) {
+	dedupRows := func(metrics []*reportingtypes.PUReportedMetric) []*reportingtypes.PUReportedMetric {
+		return lo.Filter(metrics, func(m *reportingtypes.PUReportedMetric, _ int) bool {
+			return m.PU == reportingtypes.DEDUP
+		})
+	}
+	gatewayRows := func(metrics []*reportingtypes.PUReportedMetric) []*reportingtypes.PUReportedMetric {
+		return lo.Filter(metrics, func(m *reportingtypes.PUReportedMetric, _ int) bool {
+			return m.PU == reportingtypes.GATEWAY
+		})
+	}
+
+	// newDedupProcessor builds the shared fixture: a Handle with dedup and reporting
+	// wired up, backed by a config.Config the test can mutate (for the reloadable
+	// dedupMetricsEnabled flag) and a MockDedup that allows only allowedIndex.
+	newDedupProcessor := func(t *testing.T, enableReporting bool, allowedIndex int) (*Handle, *config.Config, *testContext) {
+		t.Helper()
+		conf := config.New()
+		c := &testContext{}
+		c.Setup(t)
+		c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1) // crash recovery check
+
+		isolationStrategy, err := isolation.GetStrategy(isolation.ModeNone)
+		require.NoError(t, err)
+
+		processor := NewHandle(conf, transformer.NewSimpleClients())
+		processor.isolationStrategy = isolationStrategy
+		processor.config.archivalEnabled = config.SingleValueLoader(false)
+		processor.config.enableConcurrentStore = config.SingleValueLoader(false)
+
+		Setup(processor, c, true /* dedup */, enableReporting, t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, processor.config.asyncInit.WaitContext(ctx))
+
+		processor.dedup = c.MockDedup
+		c.MockDedup.EXPECT().Allowed(gomock.Any()).DoAndReturn(func(keys ...dedup.BatchKey) (map[dedup.BatchKey]bool, error) {
+			return map[dedup.BatchKey]bool{
+				{Index: allowedIndex, Key: "message-some-id"}: true,
+			}, nil
+		}).AnyTimes()
+
+		return processor, conf, c
+	}
+
+	// runDedupPipeline drives preprocessStage -> srcHydrationStage -> pretransformStage,
+	// which is where the new AssertKeysSubset(connectionDetailsMap, dedupStatusDetailsMap)
+	// panics and where the CreatePUDetails("", DEDUP, false, false) row is built.
+	runDedupPipeline := func(t *testing.T, processor *Handle, events []mockEventData) *transformationMessage {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		srcHydrationMsg, err := processor.preprocessStage(
+			"",
+			subJob{
+				ctx: ctx,
+				subJobs: []*jobsdb.JobT{
+					{
+						UUID:      uuid.New(),
+						JobID:     1,
+						CreatedAt: time.Date(2020, 0o4, 28, 23, 26, 0o0, 0o0, time.UTC),
+						ExpireAt:  time.Date(2020, 0o4, 28, 23, 26, 0o0, 0o0, time.UTC),
+						CustomVal: gatewayCustomVal[0],
+						EventPayload: createBatchPayload(
+							WriteKeyEnabled,
+							"2001-01-02T02:23:45.000Z",
+							events,
+							createMessagePayloadWithSameMessageId,
+						),
+						EventCount: len(events),
+						Parameters: createBatchParameters(SourceIDEnabled),
+					},
+				},
+			},
+			0,
+		)
+		require.NoError(t, err)
+
+		preTransMsg, err := processor.srcHydrationStage("", srcHydrationMsg)
+		require.NoError(t, err)
+
+		transMsg, err := processor.pretransformStage("", preTransMsg)
+		require.NoError(t, err)
+		return transMsg
+	}
+
+	twoDuplicates := []mockEventData{
+		{id: "1", originalTimestamp: "2000-01-02T01:23:45", sentAt: "2000-01-02 01:23"},
+		{id: "2", originalTimestamp: "2000-01-02T01:23:45", sentAt: "2000-01-02 01:23"},
+	}
+
+	// shared across the first two subtests: the run with the flag turned on after Setup.
+	var flagOnTransMsg *transformationMessage
+
+	t.Run("should emit exactly one dedup filtered row for a duplicate event when the flag is on", func(t *testing.T) {
+		processor, conf, c := newDedupProcessor(t, true, 0)
+		defer c.Finish()
+
+		// set after Setup: also exercises that dedupMetricsEnabled is read via .Load() at
+		// emission time, not cached at Setup time.
+		conf.Set("Reporting.dedupMetrics.enabled", true)
+
+		flagOnTransMsg = runDedupPipeline(t, processor, twoDuplicates)
+
+		rows := dedupRows(flagOnTransMsg.reportMetrics)
+		require.Len(t, rows, 1)
+		row := rows[0]
+		require.Equal(t, reportingtypes.DEDUP, row.PU)
+		require.Equal(t, "", row.InPU)
+		require.False(t, row.TerminalPU)
+		require.False(t, row.InitialPU)
+		require.Equal(t, jobsdb.Filtered.State, row.StatusDetail.Status)
+		require.Equal(t, reportingtypes.FilterEventCode, row.StatusDetail.StatusCode)
+		require.EqualValues(t, 1, row.StatusDetail.Count)
+		require.Equal(t, SourceIDEnabled, row.SourceID)
+	})
+
+	t.Run("should not emit a gateway row for the deduped event", func(t *testing.T) {
+		require.NotNil(t, flagOnTransMsg, "requires the preceding subtest to have populated the shared run")
+
+		rows := gatewayRows(flagOnTransMsg.reportMetrics)
+		require.Len(t, rows, 1, "only the surviving twin should produce a gateway row")
+		require.EqualValues(t, 1, rows[0].StatusDetail.Count, "the deduped twin must not be counted in the gateway row")
+	})
+
+	t.Run("should emit no dedup row when the flag is off", func(t *testing.T) {
+		processorRun1, _, c1 := newDedupProcessor(t, true, 0)
+		defer c1.Finish()
+		run1 := runDedupPipeline(t, processorRun1, twoDuplicates)
+		require.Empty(t, dedupRows(run1.reportMetrics))
+
+		processorRun2, _, c2 := newDedupProcessor(t, true, 0)
+		defer c2.Finish()
+		run2 := runDedupPipeline(t, processorRun2, twoDuplicates)
+		require.Empty(t, dedupRows(run2.reportMetrics))
+
+		require.Equal(t, run1.reportMetrics, run2.reportMetrics, "an otherwise identical run must produce the same report metrics")
+	})
+
+	t.Run("should emit no dedup row when reporting is disabled but the flag is on", func(t *testing.T) {
+		processor, conf, c := newDedupProcessor(t, false, 0)
+		defer c.Finish()
+
+		conf.Set("Reporting.dedupMetrics.enabled", true)
+
+		transMsg := runDedupPipeline(t, processor, twoDuplicates)
+		require.Empty(t, dedupRows(transMsg.reportMetrics))
+	})
+
+	t.Run("should increment the duplicate counter identically whether the flag is on or off", func(t *testing.T) {
+		processorOn, confOn, cOn := newDedupProcessor(t, true, 0)
+		defer cOn.Finish()
+		confOn.Set("Reporting.dedupMetrics.enabled", true)
+		runOn := runDedupPipeline(t, processorOn, twoDuplicates)
+		require.Equal(t, 1, runOn.sourceDupStats[dupStatKey{sourceID: SourceIDEnabled}])
+
+		processorOff, _, cOff := newDedupProcessor(t, true, 0)
+		defer cOff.Finish()
+		runOff := runDedupPipeline(t, processorOff, twoDuplicates)
+		require.Equal(t, 1, runOff.sourceDupStats[dupStatKey{sourceID: SourceIDEnabled}])
+	})
+
+	t.Run("should aggregate multiple duplicates from one source into a single dedup row", func(t *testing.T) {
+		threeDuplicates := []mockEventData{
+			{id: "1", originalTimestamp: "2000-01-02T01:23:45", sentAt: "2000-01-02 01:23"},
+			{id: "2", originalTimestamp: "2000-01-02T01:23:45", sentAt: "2000-01-02 01:23"},
+			{id: "3", originalTimestamp: "2000-01-02T01:23:45", sentAt: "2000-01-02 01:23"},
+		}
+		processor, conf, c := newDedupProcessor(t, true, 0)
+		defer c.Finish()
+		conf.Set("Reporting.dedupMetrics.enabled", true)
+
+		transMsg := runDedupPipeline(t, processor, threeDuplicates)
+
+		rows := dedupRows(transMsg.reportMetrics)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 2, rows[0].StatusDetail.Count)
+	})
+}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -5809,7 +5809,7 @@ func TestStoreMessageMerge(t *testing.T) {
 
 // TestDedupReporting pins the dedup report-row emission added at the duplicate-drop
 // point in preprocessStage: a single DEDUP/filtered row per drop, gated by
-// proc.isReportingEnabled() && proc.config.dedupMetricsEnabled, with no gateway row
+// proc.isReportingEnabled() && proc.config.reportingDedupMetricsEnabled, with no gateway row
 // for the dropped twin and no change to the unconditional sourceDupStats counter.
 func TestDedupReporting(t *testing.T) {
 	dedupRows := func(metrics []*reportingtypes.PUReportedMetric) []*reportingtypes.PUReportedMetric {
@@ -5825,7 +5825,7 @@ func TestDedupReporting(t *testing.T) {
 
 	// newDedupProcessor builds the shared fixture: a Handle with dedup and reporting
 	// wired up, backed by a config.Config the test can mutate (for the reloadable
-	// dedupMetricsEnabled flag) and a MockDedup that allows only allowedIndex.
+	// reportingDedupMetricsEnabled flag) and a MockDedup that allows only allowedIndex.
 	newDedupProcessor := func(t *testing.T, enableReporting bool, allowedIndex int) (*Handle, *config.Config, *testContext) {
 		t.Helper()
 		conf := config.New()
@@ -5911,7 +5911,7 @@ func TestDedupReporting(t *testing.T) {
 		processor, conf, c := newDedupProcessor(t, true, 0)
 		defer c.Finish()
 
-		// set after Setup: also exercises that dedupMetricsEnabled is read via .Load() at
+		// set after Setup: also exercises that reportingDedupMetricsEnabled is read via .Load() at
 		// emission time, not cached at Setup time.
 		conf.Set("Reporting.dedupMetrics.enabled", true)
 

--- a/processor/src_hydration_stage.go
+++ b/processor/src_hydration_stage.go
@@ -35,6 +35,7 @@ type srcHydrationMessage struct {
 	enricherStatusDetailsMap      map[string]map[string]*reportingtypes.StatusDetail
 	botManagementStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
 	eventBlockingStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
+	dedupStatusDetailsMap         map[string]map[string]*reportingtypes.StatusDetail
 	destFilterStatusDetailMap     map[string]map[string]*reportingtypes.StatusDetail
 	reportMetrics                 []*reportingtypes.PUReportedMetric
 	totalEvents                   int
@@ -168,6 +169,7 @@ func (proc *Handle) srcHydrationStage(partition string, message *srcHydrationMes
 		enricherStatusDetailsMap:      message.enricherStatusDetailsMap,
 		botManagementStatusDetailsMap: message.botManagementStatusDetailsMap,
 		eventBlockingStatusDetailsMap: message.eventBlockingStatusDetailsMap,
+		dedupStatusDetailsMap:         message.dedupStatusDetailsMap,
 		destFilterStatusDetailMap:     message.destFilterStatusDetailMap,
 		reportMetrics:                 message.reportMetrics,
 		totalEvents:                   message.totalEvents,

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -29,6 +29,7 @@ const (
 	// Module names
 	BOT_MANAGEMENT         = "bot_management"
 	EVENT_BLOCKING         = "event_blocking"
+	DEDUP                  = "dedup"
 	GATEWAY                = "gateway"
 	DESTINATION_FILTER     = "destination_filter"
 	SOURCE_HYDRATION       = "source_hydration"


### PR DESCRIPTION
# Description

First slice of the **Pipeline Inspector** work (extending the existing reporting counters so per-stage drops become visible to customers).

Duplicate events dropped by dedup are currently invisible to reporting: the only trace is the `processor_write_key_duplicate_events` prometheus counter, so events "go missing" between the gateway and downstream stages with no report row explaining why.

This PR gives duplicates a report row:

- **New PU constant** `DEDUP = "dedup"` in `utils/types/reporting_types.go`.
- **New reloadable flag** `Reporting.dedupMetrics.enabled` (default **false**), registered once in `loadReloadableConfig` and read via `.Load()` at the emission site.
- **Emission**: at the existing duplicate-drop point in the preprocess loop, gated by `proc.isReportingEnabled() && proc.config.dedupMetricsEnabled.Load()`, a `filtered`/298 row is accumulated into a new `dedupStatusDetailsMap` (same mutate/reset pattern as the adjacent bot-management and event-blocking blocks).
- **PU shape**: built in `pretransformStage` with `CreatePUDetails("", DEDUP, false, false)` — a standalone side-PU exactly like `BOT_MANAGEMENT`/`EVENT_BLOCKING`: `reportedBy=dedup`, `state=filtered`, `status_code=298`, empty `in_reported_by`, terminal=false, initial=false. Rows ride the existing storeStage reporting transaction; no reporting-plumbing changes.
- The map is threaded through `srcHydrationMessage` → `preTransformationMessage` with an `AssertKeysSubset` check, following the existing status-detail-map pattern.

**Unchanged**: the drop itself, the prometheus counter (increments identically with the flag on or off), and billing — duplicates still never reach the GATEWAY metric, so this is purely additive. With the flag off (default), every report row is identical to today.

The reporting service ingests the new `dedup` rows with no changes: there is no reportedBy allowlist on the write path, and non-canonical states keep their value in the `count` column, contributing 0 to existing success/abort/fail sums.

## Tests

**Unit**: new `TestDedupReporting` in `processor/processor_test.go` (6 subtests): exactly one dedup filtered/298 row per drop with the correct PU shape, no GATEWAY row for the deduped twin, no row with the flag off or with reporting disabled, identical duplicate-counter behaviour in both flag states, and aggregation of N duplicates into a single row with count N.

**Integration**: new "Events dropped in dedup stage" subtest in `TestReportingDroppedEvents` (`integration_test/reporting_dropped_events`): boots the full server with dedup and the metrics flag on, sends 1 event + 2 duplicates, and asserts the `reports` table gets a `dedup`/`filtered`/298 row with count 2 (empty `in_pu`, non-terminal, non-initial) while the gateway PU counts only the surviving event. `runRudderServer` gained a variadic config-overrides parameter; existing subtests are unchanged.

## Linear Ticket

[pipe-3285
](https://linear.app/rudderstack/issue/PIPE-3285/collect-metrics-for-events-dropped-due-to-dedup)
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
