### PR TITLE
fix: race conditions while counting initial pending events can cause wrong counting

### DIFF
--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -88,6 +88,20 @@ func (r *Locker) TryLockWithCtx(ctx context.Context) bool {
 	return false
 }
 
+// TryLock tries to acquire a lock without blocking and returns false if the lock is already held,
+// by a reader or a writer, otherwise returns true.
+func (r *Locker) TryLock() bool {
+	start := time.Now()
+	if r.m.TryLock() {
+		acquired := time.Now()
+		r.writeLockWait.Since(start)
+		r.tryLockStart = start
+		r.tryLockAcquired = acquired
+		return true
+	}
+	return false
+}
+
 // Unlock releases a lock
 func (r *Locker) Unlock() {
 	r.m.Unlock()

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -148,8 +147,9 @@ type JobsDB interface {
 	// On single-consumer handles it behaves per-job. Used by partition migration.
 	GetPendingConsumerJobs(ctx context.Context, states []string, params GetQueryParams) (JobsResult, error)
 
-	// GetPileUpCounts returns statistics of incomplete jobs grouped by workspace ID,
-	// custom value, and destination ID.
+	// GetPileUpCounts returns statistics of the jobs that were incomplete as of cutoffTime, grouped
+	// by workspace ID, custom value, and destination ID. Jobs created after the cutoff, along with
+	// statuses recorded after it, are excluded from the counts.
 	GetPileUpCounts(ctx context.Context, cutoffTime time.Time, increaseFunc rmetrics.IncreasePendingEventsFunc) (err error)
 
 	// GetDistinctParameterValues returns the list of distinct parameter("source_id", "destination_id", "workspace_id") values inside the jobs tables filtering for the passed customVal
@@ -348,8 +348,11 @@ type Handle struct {
 
 	// skipSetupDBSetup is useful for testing as we mock the database client
 	// TriggerAddNewDS, TriggerCompaction is useful for triggering addNewDS to run from tests.
-	TriggerAddNewDS   func() <-chan time.Time
-	compactionPaused  atomic.Bool
+	TriggerAddNewDS func() <-chan time.Time
+	// compactionLock guards the datasets against compaction: compaction takes it exclusively and
+	// skips the round if it is already taken, while operations that need the datasets to stay put
+	// for their whole duration, e.g. [Handle.GetPileUpCounts], take it for reading.
+	compactionLock    *lock.Locker
 	TriggerCompaction func() <-chan time.Time
 	TriggerRefreshDS  func() <-chan time.Time
 

--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -38,14 +38,17 @@ func (jd *Handle) compactionLoop(ctx context.Context) {
 	for {
 		select {
 		case <-jd.TriggerCompaction():
-			if jd.compactionPaused.Load() {
-				jd.logger.Debugn("compaction loop paused")
-				continue
-			}
 		case <-ctx.Done():
 			return
 		}
+		// Skip this round instead of queueing behind the reader currently holding the lock: it needs
+		// the datasets to stay put for its whole duration and compaction can always run next round.
+		if !jd.compactionLock.TryLock() {
+			jd.logger.Debugn("compaction loop paused")
+			continue
+		}
 		compact := func() error {
+			defer jd.compactionLock.Unlock()
 			start := time.Now()
 			jd.logger.Debugn("Start", logger.NewStringField("operation", "compactionLoop"))
 			timeoutCtx, cancel := context.WithTimeout(ctx, jd.conf.compaction.compactionTimeout.Load())

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -83,17 +83,29 @@ var cacheParameterFilters = []string{"source_id", "destination_id"}
 
 const consumerParamName = "consumer" // the name of the consumer parameter, used for multi-consumer scoping of queries and cache entries
 
+// GetPileUpCounts counts the jobs that were pending as of cutoffTime, grouped by workspace ID,
+// custom value and destination ID, and reports them through increaseFunc.
+//
+// cutoffTime bounds both sides of the count: only jobs created before it are considered, and only
+// statuses recorded before it are taken into account when deciding whether a job is still pending.
+// Jobs stored - and statuses recorded - after the cutoff are the caller's responsibility to account
+// for separately, so that a job is never counted twice, nor missed, when writers are running
+// concurrently with this query.
 func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, increaseFunc rmetrics.IncreasePendingEventsFunc) error {
-	// pause compaction to get a consistent view during pileup count
-	jd.compactionPaused.Store(true)
-	defer jd.compactionPaused.Store(false)
+	// Wait for an in-flight compaction to finish and keep the next ones out for the duration of the
+	// count, so that the dataset list acquired below stays valid throughout.
+	if !jd.compactionLock.RTryLockWithCtx(ctx) {
+		return fmt.Errorf("could not acquire the compaction read lock: %w", ctx.Err())
+	}
+	defer jd.compactionLock.RUnlock()
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return err
 	}
 	defer release()
 
-	// Single-consumer: one pending row per job, destination_id read from the job's parameters.
+	// Single-consumer: one pending row per job, destination_id read from the job's parameters,
+	// counting each job created before the cutoff whose latest pre-cutoff status is missing or non-terminal.
 	queryString := `WITH pending AS (
 	SELECT
 		j.workspace_id AS workspace_id,
@@ -103,7 +115,7 @@ func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, inc
 		%[1]q j
 		LEFT JOIN (SELECT DISTINCT ON (job_id) job_id, job_state FROM %[2]q WHERE exec_time < $1 ORDER BY job_id ASC, id DESC) s ON j.job_id = s.job_id
 	WHERE
-		s.job_id is null OR s.job_state = ANY($2)
+		j.created_at < $1 AND (s.job_id is null OR s.job_state = ANY($2))
 )
 SELECT
 	workspace_id,
@@ -113,8 +125,8 @@ SELECT
 FROM pending GROUP BY workspace_id, custom_val, destination_id;`
 
 	// Multi-consumer: assuming for now that a consumer IS a destination, so fan out per consumer over the narrow consumers
-	// array (no payload), counting each (job, consumer) whose latest pre-cutoff status is missing or
-	// non-terminal. The per-consumer latest status uses the (job_id, consumer, id DESC) index.
+	// array (no payload), counting each (job, consumer) - the job created before the cutoff - whose
+	// latest pre-cutoff status is missing or non-terminal. The per-consumer latest status uses the (job_id, consumer, id DESC) index.
 	if jd.conf.multiConsumer {
 		queryString = `WITH pending AS (
 	SELECT
@@ -128,7 +140,7 @@ FROM pending GROUP BY workspace_id, custom_val, destination_id;`
 			SELECT job_state FROM %[2]q WHERE job_id = j.job_id AND consumer = c.consumer AND exec_time < $1 ORDER BY id DESC LIMIT 1
 		) s ON true
 	WHERE
-		s.job_state is null OR s.job_state = ANY($2)
+		j.created_at < $1 AND (s.job_state is null OR s.job_state = ANY($2))
 )
 SELECT
 	workspace_id,

--- a/jobsdb/jobsdb_lifecycle.go
+++ b/jobsdb/jobsdb_lifecycle.go
@@ -59,6 +59,7 @@ func (jd *Handle) init() {
 		jd.stats = stats.Default
 	}
 	jd.dsListLock = lock.NewLocker("dsListLock", jd.tablePrefix, jd.stats)
+	jd.compactionLock = lock.NewLocker("compactionLock", jd.tablePrefix, jd.stats)
 
 	jd.loadConfig()
 

--- a/jobsdb/jobsdb_pileup_test.go
+++ b/jobsdb/jobsdb_pileup_test.go
@@ -2,6 +2,7 @@ package jobsdb
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -256,4 +257,139 @@ func TestJobsdbPileupCountMultiConsumer(t *testing.T) {
 		WorkspaceId: workspaceID, CustomVal: customVal, Consumer: "A",
 	}}))
 	require.Equal(t, map[string]int{"A": 1, "B": 1}, pileup())
+}
+
+// TestJobsdbPileupCountCutoff verifies that the cutoff bounds both sides of the count: jobs created
+// after it are not counted, no matter whether they are pending or not. Counting them would make the
+// caller, which accounts for jobs stored after the cutoff on its own, count them twice.
+func TestJobsdbPileupCountCutoff(t *testing.T) {
+	_ = startPostgres(t)
+
+	const (
+		customVal   = "CUTOFF"
+		workspaceID = "ws"
+	)
+	generateJobs := func(numOfJob int, consumers []string) []*JobT {
+		js := make([]*JobT, numOfJob)
+		for i := range numOfJob {
+			js[i] = &JobT{
+				WorkspaceId:  workspaceID,
+				Parameters:   []byte(`{"source_id":"sourceID","destination_id":"destinationID"}`),
+				EventPayload: []byte(`{"testKey":"testValue"}`),
+				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:         uuid.New(),
+				CustomVal:    customVal,
+				EventCount:   1,
+				Consumers:    consumers,
+			}
+		}
+		return js
+	}
+
+	for _, multiConsumer := range []bool{false, true} {
+		t.Run("multiConsumer="+strconv.FormatBool(multiConsumer), func(t *testing.T) {
+			c := config.New()
+			c.Set("JobsDB.maxDSSize", 1) // create 1 dataset per event, so that the cutoff is applied across datasets
+
+			jdb := Handle{config: c}
+			jdb.conf.multiConsumer = multiConsumer
+			var consumers []string
+			if multiConsumer {
+				consumers = []string{"destinationID"}
+			}
+			require.NoError(t, jdb.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+			defer jdb.TearDown()
+
+			pileup := func(cutoff time.Time) int {
+				var count int
+				require.NoError(t, jdb.GetPileUpCounts(context.Background(), cutoff, func(_, _, _, _ string, value float64) {
+					count += int(value)
+				}))
+				return count
+			}
+			// dbNow returns the database's current time, the same clock that stamps created_at.
+			dbNow := func() time.Time {
+				var now time.Time
+				require.NoError(t, jdb.dbHandle.QueryRow("SELECT NOW()").Scan(&now))
+				return now
+			}
+
+			require.NoError(t, jdb.Store(context.Background(), generateJobs(5, consumers)))
+			cutoff := dbNow()
+			require.NoError(t, jdb.Store(context.Background(), generateJobs(3, consumers)))
+
+			require.Equal(t, 5, pileup(cutoff), "jobs stored after the cutoff should not be counted")
+			require.Equal(t, 8, pileup(dbNow()), "all jobs should be counted with a cutoff past the last store")
+
+			// A job stored after the cutoff stays uncounted even once it is terminal.
+			stored, err := jdb.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: lo.Ternary(multiConsumer, "destinationID", "")})
+			require.NoError(t, err)
+			require.Len(t, stored.Jobs, 8)
+			last := stored.Jobs[len(stored.Jobs)-1]
+			require.NoError(t, jdb.UpdateJobStatus(context.Background(), []*JobStatusT{{
+				JobID: last.JobID, JobState: Succeeded.State, AttemptNum: 1,
+				ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "200",
+				ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`),
+				WorkspaceId: workspaceID, CustomVal: customVal, Consumer: lo.Ternary(multiConsumer, "destinationID", ""),
+			}}))
+			require.Equal(t, 5, pileup(cutoff))
+			require.Equal(t, 7, pileup(dbNow()))
+		})
+	}
+}
+
+// TestJobsdbPileupCountCompactionBarrier verifies that pileup counting and compaction are mutually
+// exclusive: the count waits for an in-flight compaction to finish, and a compaction triggered while
+// a count is in progress skips its round instead of moving datasets under it.
+func TestJobsdbPileupCountCompactionBarrier(t *testing.T) {
+	_ = startPostgres(t)
+
+	const customVal = "BARRIER"
+
+	c := config.New()
+	c.Set("JobsDB.maxDSSize", 1)
+	jdb := Handle{config: c}
+	require.NoError(t, jdb.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+	defer jdb.TearDown()
+
+	require.NoError(t, jdb.Store(context.Background(), []*JobT{{
+		UUID: uuid.New(), UserID: "u", CustomVal: customVal, Parameters: []byte(`{}`),
+		EventPayload: []byte(`{}`), EventCount: 1, WorkspaceId: "ws",
+	}}))
+
+	t.Run("a count waits for an in-flight compaction", func(t *testing.T) {
+		require.True(t, jdb.compactionLock.TryLock(), "no one else should be holding the compaction lock")
+		defer jdb.compactionLock.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		err := jdb.GetPileUpCounts(ctx, time.Now(), func(_, _, _, _ string, _ float64) {
+			t.Error("no counting should happen while compaction is in progress")
+		})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("a compaction skips its round during a count", func(t *testing.T) {
+		counting := make(chan struct{})
+		release := make(chan struct{})
+		var count atomic.Int64
+		done := make(chan error, 1)
+		go func() {
+			done <- jdb.GetPileUpCounts(context.Background(), time.Now(), func(_, _, _, _ string, value float64) {
+				if count.Add(int64(value)) == 1 {
+					close(counting)
+					<-release
+				}
+			})
+		}()
+
+		<-counting // the count is in progress and holding the compaction lock
+		require.False(t, jdb.compactionLock.TryLock(), "compaction should skip its round while a count is in progress")
+		close(release)
+
+		require.NoError(t, <-done)
+		require.EqualValues(t, 1, count.Load())
+		require.True(t, jdb.compactionLock.TryLock(), "compaction should be able to run once the count is over")
+		jdb.compactionLock.Unlock()
+	})
 }

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -89,8 +90,16 @@ func (proc *LifecycleManager) Start() error {
 	var wg sync.WaitGroup
 	proc.waitGroup = &wg
 
+	// Reset the registry and capture the pileup cutoff before starting any of the processor's loops:
+	// the processor is the only writer of router & batch router jobs and it always starts before
+	// router and batch router, so no job and no status can be written below the cutoff once it has
+	// been captured here. Jobs pending below the cutoff are counted by countPendingEvents, everything
+	// above it is accounted for by the pending events jobsdb wrappers as it happens.
+	proc.pendingEventsRegistry.Reset()
+	pendingEventsCutoff := time.Now()
+
 	wg.Go(func() {
-		if err := proc.Handle.countPendingEvents(currentCtx); err != nil {
+		if err := proc.Handle.countPendingEvents(currentCtx, pendingEventsCutoff); err != nil {
 			proc.Handle.logger.Errorn("Error counting pending events", obskit.Error(err))
 		}
 	})

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -4213,7 +4213,16 @@ func (proc *Handle) pipelineDelayStats(partition string, first, last *jobsdb.Job
 	proc.statsFactory.NewTaggedStat("pipeline_delay_max_seconds", stats.GaugeType, stats.Tags{"partition": partition, "module": "processor"}).Gauge(firstJobDelay)
 }
 
-func (proc *Handle) countPendingEvents(ctx context.Context) error {
+// countPendingEvents seeds the pending events registry with the jobs that were already pending as of
+// cutoff, i.e. before this processor started producing jobs.
+//
+// The registry must have been reset by the caller, and cutoff captured, before any writer is started:
+// the processor is the only writer of router & batch router jobs and it always starts before router
+// and batch router, so nothing can be written below the cutoff once it has been captured. Everything
+// below the cutoff is therefore accounted for by the queries here and everything above it by the
+// increase/decrease calls of the pending events jobsdb wrappers, with no overlap in between. Metrics
+// are published to the global registry once the baseline is in place.
+func (proc *Handle) countPendingEvents(ctx context.Context, cutoff time.Time) error {
 	dbs := map[string]jobsdb.JobsDB{"rt": proc.routerDB, "batch_rt": proc.batchRouterDB}
 	if proc.procDB != nil {
 		dbs["proc"] = proc.procDB
@@ -4221,23 +4230,30 @@ func (proc *Handle) countPendingEvents(ctx context.Context) error {
 	jobdDBQueryRequestTimeout := proc.conf.GetDurationVar(600, time.Second, "JobsDB.GetPileUpCounts.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
 	jobdDBMaxRetries := proc.conf.GetReloadableIntVar(2, 1, "JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries")
 
+	defer proc.pendingEventsRegistry.Publish()
 	err := misc.RetryWithNotify(ctx,
 		jobdDBQueryRequestTimeout,
 		jobdDBMaxRetries.Load(),
 		func(ctx context.Context) error {
-			startTime := time.Now()
-			proc.pendingEventsRegistry.Reset()
-			defer proc.pendingEventsRegistry.Publish()
+			// Counts are accumulated separately and applied to the registry only after all queries
+			// have succeeded: an attempt that fails halfway must not leave its partial counts behind
+			// for the next attempt to add on top of, and the registry cannot be reset in between
+			// without discarding the concurrent increases & decreases of the running processor.
+			baseline := &pendingEventsBaseline{}
 			g, ctx := errgroup.WithContext(ctx)
 			for tablePrefix, db := range dbs {
 				g.Go(func() error {
-					if err := db.GetPileUpCounts(ctx, startTime, proc.pendingEventsRegistry.IncreasePendingEvents); err != nil {
+					if err := db.GetPileUpCounts(ctx, cutoff, baseline.add); err != nil {
 						return fmt.Errorf("pileup counts for %s: %w", tablePrefix, err)
 					}
 					return nil
 				})
 			}
-			return g.Wait()
+			if err := g.Wait(); err != nil {
+				return err
+			}
+			baseline.flush(proc.pendingEventsRegistry.IncreasePendingEvents)
+			return nil
 		}, func(attempt int) {
 			proc.logger.Warnn("Timeout during GetPileUpCounts",
 				logger.NewIntField("attempt", int64(attempt)))
@@ -4247,6 +4263,38 @@ func (proc *Handle) countPendingEvents(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// pendingEventsBaseline accumulates pileup counts, reported concurrently by multiple jobsdbs, until
+// they are ready to be applied to the pending events registry.
+type pendingEventsBaseline struct {
+	mu     sync.Mutex
+	counts map[pendingEventsBaselineKey]float64
+}
+
+type pendingEventsBaselineKey struct {
+	tablePrefix   string
+	workspaceID   string
+	destType      string
+	destinationID string
+}
+
+func (b *pendingEventsBaseline) add(tablePrefix, workspaceID, destType, destinationID string, value float64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.counts == nil {
+		b.counts = make(map[pendingEventsBaselineKey]float64)
+	}
+	b.counts[pendingEventsBaselineKey{tablePrefix, workspaceID, destType, destinationID}] += value
+}
+
+func (b *pendingEventsBaseline) flush(increaseFunc rmetrics.IncreasePendingEventsFunc) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for key, value := range b.counts {
+		increaseFunc(key.tablePrefix, key.workspaceID, key.destType, key.destinationID, value)
+	}
+	b.counts = nil
 }
 
 // shouldSample sampling percentage precision can be with two decimals like 12.34%.


### PR DESCRIPTION
# Description

Pending event counts can drift at startup, since the pileup count and the live counters don't agree on a single boundary:

- Jobs stored by the processor while the count is running are counted twice: the cutoff is applied to statuses (`exec_time`) but not to jobs, so the query counts them, and so does the jobsdb wrapper's increase.
- The registry is reset after the cutoff is captured and once more on every retry attempt, discarding whatever the running processor has registered in the meantime.
- Pausing compaction is advisory - it only keeps new rounds from starting - so a compaction already in flight keeps moving datasets while the count queries them.

Key changes:

- The cutoff and the registry reset move ahead of the processor's loops. The processor is the only writer of rt/batch_rt jobs and always starts before router & batch router, so nothing can be written below the cutoff once it is captured, and everything above it is accounted for by the pending events jobsdb wrappers.
- `GetPileUpCounts` applies the cutoff to both sides, `created_at` for jobs and `exec_time` for statuses.
- Retries no longer reset the registry: counts are accumulated per attempt and applied only after every query has succeeded.
- The compaction pause becomes a lock - taken exclusively by compaction, which skips the round if it can't get it, and for reading by the count, which waits for an in-flight compaction and keeps the next ones out.

## Linear Ticket

resolves 3299

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
