### PR TITLE
chore: webhook reasons

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1052,11 +1052,14 @@ var _ = Describe("Gateway", func() {
 					stat := statsStore.Get(
 						"gateway.write_key_dropped_requests",
 						map[string]string{
-							"source":        rCtxEnabled.SourceTag(),
-							"sourceID":      rCtxEnabled.SourceID,
-							"workspaceId":   rCtxEnabled.WorkspaceID,
-							"writeKey":      rCtxEnabled.WriteKey,
-							"reqType":       "alias",
+							"source":      rCtxEnabled.SourceTag(),
+							"sourceID":    rCtxEnabled.SourceID,
+							"workspaceId": rCtxEnabled.WorkspaceID,
+							"writeKey":    rCtxEnabled.WriteKey,
+							"reqType":     "alias",
+							// a drop now says why: this is what lets a consumer tell a rate limit from any other
+							// reason a request was turned away
+							"reason":        gwtypes.ReasonRateLimit.Value(),
 							"sourceType":    rCtxEnabled.SourceCategory,
 							"sdkVersion":    "",
 							"sourceDefName": rCtxEnabled.SourceDefName,

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -226,13 +226,25 @@ func (gw *Handle) userWebRequestWorkerProcess(userWebRequestWorker *userWebReque
 				switch {
 				case errors.Is(err, errRequestDropped):
 					req.done <- response.TooManyRequests
-					sourceStats[sourceTag].RequestDropped()
+					sourceStats[sourceTag].RequestDropped(gwtypes.ReasonRateLimit)
 				case errors.Is(err, errRequestSuppressed):
 					req.done <- "" // no error
 					sourceStats[sourceTag].RequestSuppressed()
 				default:
+					// Most of these errors are built as errors.New(response.X), so the message is already a bounded
+					// identifier and resolves to the reason declared for it. Anything else reports the catch-all and
+					// has its text logged, where it stays searchable without becoming an unbounded label.
+					reason, known := gwtypes.StatReasonForMessage(err.Error())
+					if !known {
+						reason = gwtypes.ReasonRequestProcessingFailed
+						gw.logger.Errorn("building job data from request",
+							obskit.SourceID(arctx.SourceID),
+							obskit.WorkspaceID(arctx.WorkspaceID),
+							obskit.Error(err),
+						)
+					}
 					req.done <- err.Error()
-					sourceStats[sourceTag].RequestEventsFailed(jobData.numEvents, err.Error())
+					sourceStats[sourceTag].RequestEventsFailed(jobData.numEvents, reason)
 				}
 				continue
 			}
@@ -251,7 +263,7 @@ func (gw *Handle) userWebRequestWorkerProcess(userWebRequestWorker *userWebReque
 				}
 			} else {
 				req.done <- response.EmptyBatchPayload
-				sourceStats[sourceTag].RequestFailed(response.EmptyBatchPayload)
+				sourceStats[sourceTag].RequestFailed(gwtypes.ReasonEmptyBatchPayload)
 			}
 		}
 
@@ -268,7 +280,7 @@ func (gw *Handle) userWebRequestWorkerProcess(userWebRequestWorker *userWebReque
 			err, found := errorMessagesMap[batch[0].UUID]
 			sourceTag := jobSourceTagMap[batch[0].UUID]
 			if found {
-				sourceStats[sourceTag].RequestEventsFailed(len(batch), "storeFailed")
+				sourceStats[sourceTag].RequestEventsFailed(len(batch), gwtypes.ReasonStoreFailed)
 				jobIDReqMap[batch[0].UUID].errors = append(jobIDReqMap[batch[0].UUID].errors, err)
 			} else {
 				sourceStats[sourceTag].RequestEventsSucceeded(len(batch))
@@ -643,7 +655,7 @@ func (gw *Handle) getPayload(arctx *gwtypes.AuthRequestContext, r *http.Request,
 			WorkspaceID: arctx.WorkspaceID,
 			SourceType:  arctx.SourceCategory,
 		}
-		stat.RequestFailed("requestBodyReadFailed")
+		stat.RequestFailed(gwtypes.ReasonRequestBodyReadFailed)
 		stat.Report(gw.stats)
 
 		return nil, err
@@ -751,7 +763,7 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 
 		body, err = gw.getPayloadFromRequest(r)
 		if err != nil {
-			stat.RequestFailed("requestBodyReadFailed")
+			stat.RequestFailed(gwtypes.ReasonRequestBodyReadFailed)
 			stat.Report(gw.stats)
 			goto requestError
 		}
@@ -766,10 +778,10 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 			})
 			if err = gw.storeJobs(ctx, jobs); err != nil {
 				for _, jwm := range jobsWithMetadata {
-					jwm.stat.EventsFailed(1, "storeFailed")
+					jwm.stat.EventsFailed(1, gwtypes.ReasonStoreFailed)
 					jwm.stat.Report(gw.stats)
 				}
-				stat.RequestFailed("storeFailed")
+				stat.RequestFailed(gwtypes.ReasonStoreFailed)
 				stat.Report(gw.stats)
 				goto requestError
 			}
@@ -880,7 +892,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 
 	err = jsonrs.Unmarshal(body, &messages)
 	if err != nil {
-		stat.RequestFailed(response.InvalidJSON)
+		stat.RequestFailed(gwtypes.ReasonInvalidJSON)
 		stat.Report(gw.stats)
 		gw.logger.Errorn("invalid json in request", obskit.Error(err))
 		return nil, errors.New((response.InvalidJSON))
@@ -888,7 +900,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 	gw.requestSizeStat.Observe(float64(len(body)))
 
 	if len(messages) == 0 {
-		stat.RequestFailed(response.NotRudderEvent)
+		stat.RequestFailed(gwtypes.ReasonNotRudderEvent)
 		stat.Report(gw.stats)
 		gw.logger.Errorn("no messages in request")
 		return nil, errors.New((response.NotRudderEvent))
@@ -918,7 +930,11 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 			loggerFields = append(loggerFields, obskit.Error(err))
 			gw.logger.Errorn("invalid message in request",
 				loggerFields...)
-			stat.RequestEventsFailed(1, errMsg)
+			reason, known := gwtypes.StatReasonForMessage(errMsg)
+			if !known {
+				reason = gwtypes.ReasonValidationFailed
+			}
+			stat.RequestEventsFailed(1, reason)
 			stat.Report(gw.stats)
 			return nil, errors.New(response.NotRudderEvent)
 		}
@@ -1019,7 +1035,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 		payload, err = jsonrs.Marshal(eventBatch)
 		if err != nil {
 			err = fmt.Errorf("marshalling event batch: %w", err)
-			stat.RequestEventsFailed(1, err.Error())
+			stat.RequestEventsFailed(1, gwtypes.ReasonMarshalEventBatchFailed)
 			stat.Report(gw.stats)
 			loggerFields := msg.Properties.LoggerFields()
 			loggerFields = append(loggerFields, obskit.Error(err))

--- a/gateway/handle_http_auth.go
+++ b/gateway/handle_http_auth.go
@@ -23,14 +23,15 @@ func (gw *Handle) writeKeyAuth(delegate http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		reqType := r.Context().Value(gwtypes.CtxParamCallType).(string)
 		var errorMessage string
+		var reason gwtypes.StatReason
 		var arctx *gwtypes.AuthRequestContext
 		defer func() {
 			gw.handleHttpError(w, r, errorMessage)
-			gw.handleFailureStats(errorMessage, reqType, arctx)
+			gw.handleFailureStats(errorMessage, reason, reqType, arctx)
 		}()
 		writeKey, _, ok := r.BasicAuth()
 		if !ok || writeKey == "" {
-			errorMessage = response.NoWriteKeyInBasicAuth
+			errorMessage, reason = response.NoWriteKeyInBasicAuth, gwtypes.ReasonNoWriteKeyInBasicAuth
 			return
 		}
 		arctx = gw.authRequestContextForWriteKey(writeKey)
@@ -41,13 +42,13 @@ func (gw *Handle) writeKeyAuth(delegate http.HandlerFunc) http.HandlerFunc {
 				WriteKey: writeKey,
 				ReqType:  reqType,
 			}
-			stat.RequestFailed("invalidWriteKey")
+			stat.RequestFailed(gwtypes.ReasonWriteKeyNotFound)
 			stat.Report(gw.stats)
-			errorMessage = response.InvalidWriteKey
+			errorMessage, reason = response.InvalidWriteKey, gwtypes.ReasonInvalidWriteKey
 			return
 		}
 		if !arctx.SourceEnabled {
-			errorMessage = response.SourceDisabled
+			errorMessage, reason = response.SourceDisabled, gwtypes.ReasonSourceDisabled
 			return
 		}
 		augmentAuthRequestContext(arctx, r)
@@ -64,9 +65,10 @@ func (gw *Handle) webhookAuth(delegate http.HandlerFunc) http.HandlerFunc {
 		reqType := r.Context().Value(gwtypes.CtxParamCallType).(string)
 		var arctx *gwtypes.AuthRequestContext
 		var errorMessage string
+		var reason gwtypes.StatReason
 		defer func() {
 			gw.handleHttpError(w, r, errorMessage)
-			gw.handleFailureStats(errorMessage, reqType, arctx)
+			gw.handleFailureStats(errorMessage, reason, reqType, arctx)
 		}()
 
 		var writeKey string
@@ -76,16 +78,16 @@ func (gw *Handle) webhookAuth(delegate http.HandlerFunc) http.HandlerFunc {
 			writeKey, _, _ = r.BasicAuth()
 		}
 		if writeKey == "" {
-			errorMessage = response.NoWriteKeyInQueryParams
+			errorMessage, reason = response.NoWriteKeyInQueryParams, gwtypes.ReasonNoWriteKeyInQueryParams
 			return
 		}
 		arctx = gw.authRequestContextForWriteKey(writeKey)
 		if arctx == nil || arctx.SourceCategory != "webhook" {
-			errorMessage = response.InvalidWriteKey
+			errorMessage, reason = response.InvalidWriteKey, gwtypes.ReasonInvalidWriteKey
 			return
 		}
 		if !arctx.SourceEnabled {
-			errorMessage = response.SourceDisabled
+			errorMessage, reason = response.SourceDisabled, gwtypes.ReasonSourceDisabled
 			return
 		}
 		augmentAuthRequestContext(arctx, r)
@@ -100,23 +102,24 @@ func (gw *Handle) sourceIDAuth(delegate http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		reqType := r.Context().Value(gwtypes.CtxParamCallType).(string)
 		var errorMessage string
+		var reason gwtypes.StatReason
 		var arctx *gwtypes.AuthRequestContext
 		defer func() {
 			gw.handleHttpError(w, r, errorMessage)
-			gw.handleFailureStats(errorMessage, reqType, arctx)
+			gw.handleFailureStats(errorMessage, reason, reqType, arctx)
 		}()
 		sourceID := r.Header.Get("X-Rudder-Source-Id")
 		if sourceID == "" {
-			errorMessage = response.NoSourceIdInHeader
+			errorMessage, reason = response.NoSourceIdInHeader, gwtypes.ReasonNoSourceIDInHeader
 			return
 		}
 		arctx = gw.authRequestContextForSourceID(sourceID)
 		if arctx == nil {
-			errorMessage = response.InvalidSourceID
+			errorMessage, reason = response.InvalidSourceID, gwtypes.ReasonInvalidSourceID
 			return
 		}
 		if !arctx.SourceEnabled {
-			errorMessage = response.SourceDisabled
+			errorMessage, reason = response.SourceDisabled, gwtypes.ReasonSourceDisabled
 			return
 		}
 		augmentAuthRequestContext(arctx, r)
@@ -133,19 +136,20 @@ func (gw *Handle) sourceIDAuth(delegate http.HandlerFunc) http.HandlerFunc {
 func (gw *Handle) authDestIDForSource(delegate http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var errorMessage, reqType string
+		var reason gwtypes.StatReason
 		var arctx *gwtypes.AuthRequestContext
 		defer func() {
 			gw.handleHttpError(w, r, errorMessage)
-			gw.handleFailureStats(errorMessage, reqType, arctx)
+			gw.handleFailureStats(errorMessage, reason, reqType, arctx)
 		}()
 		reqType, ok := gwCtx.GetRequestTypeFromCtx(r.Context())
 		if !ok {
-			errorMessage = "unable to get request type from context"
+			errorMessage, reason = "unable to get request type from context", gwtypes.ReasonInvalidRequestContext
 			return
 		}
 		arctx, ok = gwCtx.GetAuthRequestFromCtx(r.Context())
 		if !ok {
-			errorMessage = "unable to get AuthRequest from context"
+			errorMessage, reason = "unable to get AuthRequest from context", gwtypes.ReasonInvalidRequestContext
 			return
 		}
 
@@ -156,18 +160,18 @@ func (gw *Handle) authDestIDForSource(delegate http.HandlerFunc) http.HandlerFun
 				delegate.ServeHTTP(w, r)
 				return
 			}
-			errorMessage = response.NoDestinationIDInHeader
+			errorMessage, reason = response.NoDestinationIDInHeader, gwtypes.ReasonNoDestinationIDInHeader
 			return
 		}
 		destination, found := lo.Find(arctx.Source.Destinations, func(dest backendconfig.DestinationT) bool {
 			return dest.ID == destinationID
 		})
 		if !found {
-			errorMessage = response.InvalidDestinationID
+			errorMessage, reason = response.InvalidDestinationID, gwtypes.ReasonInvalidDestinationID
 			return
 		}
 		if !destination.Enabled {
-			errorMessage = response.DestinationDisabled
+			errorMessage, reason = response.DestinationDisabled, gwtypes.ReasonDestinationDisabled
 			return
 		}
 		arctx.DestinationID = destinationID
@@ -184,7 +188,7 @@ func (gw *Handle) replaySourceIDAuth(delegate http.HandlerFunc) http.HandlerFunc
 		s, ok := gw.sourceIDSourceMap[arctx.SourceID]
 		if !ok || !s.IsReplaySource() {
 			gw.handleHttpError(w, r, response.InvalidReplaySource)
-			gw.handleFailureStats(response.InvalidReplaySource, "replay", arctx)
+			gw.handleFailureStats(response.InvalidReplaySource, gwtypes.ReasonInvalidReplaySource, "replay", arctx)
 			return
 		}
 		delegate.ServeHTTP(w, r)
@@ -267,7 +271,7 @@ func (gw *Handle) handleHttpError(w http.ResponseWriter, r *http.Request, errorM
 	}
 }
 
-func (gw *Handle) handleFailureStats(errorMessage, reqType string, arctx *gwtypes.AuthRequestContext) {
+func (gw *Handle) handleFailureStats(errorMessage string, reason gwtypes.StatReason, reqType string, arctx *gwtypes.AuthRequestContext) {
 	if errorMessage != "" {
 		var stat gwstats.SourceStat
 		switch errorMessage {
@@ -310,7 +314,7 @@ func (gw *Handle) handleFailureStats(errorMessage, reqType string, arctx *gwtype
 				SourceDefName: arctx.SourceDefName,
 			}
 		}
-		stat.RequestFailed(response.GetStatus(errorMessage))
+		stat.RequestFailed(reason)
 		stat.Report(gw.stats)
 	}
 }

--- a/gateway/handle_http_beacon.go
+++ b/gateway/handle_http_beacon.go
@@ -5,9 +5,9 @@ import (
 
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-
 	gwstats "github.com/rudderlabs/rudder-server/gateway/internal/stats"
 	"github.com/rudderlabs/rudder-server/gateway/response"
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
 )
 
 // beaconBatchHandler can handle beacon batch requests where writeKey is passed as a query param
@@ -34,7 +34,7 @@ func (gw *Handle) beaconInterceptor(delegate http.HandlerFunc) http.HandlerFunc 
 				WriteKey: "invalidWriteKey",
 				ReqType:  "beacon",
 			}
-			stat.RequestFailed("invalidWriteKey")
+			stat.RequestFailed(gwtypes.ReasonWriteKeyNotFound)
 			stat.Report(gw.stats)
 			gw.logger.Infon("response",
 				logger.NewStringField("ip", kithttputil.GetRequestIP(r)),

--- a/gateway/handle_http_beacon.go
+++ b/gateway/handle_http_beacon.go
@@ -5,6 +5,7 @@ import (
 
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	gwstats "github.com/rudderlabs/rudder-server/gateway/internal/stats"
 	"github.com/rudderlabs/rudder-server/gateway/response"
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"

--- a/gateway/handle_http_pixel.go
+++ b/gateway/handle_http_pixel.go
@@ -16,6 +16,7 @@ import (
 
 	gwstats "github.com/rudderlabs/rudder-server/gateway/internal/stats"
 	"github.com/rudderlabs/rudder-server/gateway/response"
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
 )
 
 // pixelPageHandler can handle pixel page requests where everything is passed as query params.
@@ -77,7 +78,7 @@ func (gw *Handle) pixelInterceptor(reqType string, next http.HandlerFunc) http.H
 				WriteKey: "NoWriteKeyInQueryParams",
 				ReqType:  reqType,
 			}
-			stat.RequestFailed("NoWriteKeyInQueryParams")
+			stat.RequestFailed(gwtypes.ReasonWriteKeyMissingFromQuery)
 			stat.Report(gw.stats)
 			gw.logger.Infon("Error while handling request",
 				logger.NewStringField("ip", kithttputil.GetRequestIP(r)),

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -174,9 +174,9 @@ func (gw *Handle) Setup(
 	gw.msgValidator = validator.NewValidateMediator(gw.logger, stream.NewMessagePropertiesValidator())
 
 	gw.webhookAuthMiddleware = auth.NewWebhookAuth(
-		func(w http.ResponseWriter, r *http.Request, errorMessage string, authCtx *gwtypes.AuthRequestContext) {
+		func(w http.ResponseWriter, r *http.Request, errorMessage string, reason gwtypes.StatReason, authCtx *gwtypes.AuthRequestContext) {
 			gw.handleHttpError(w, r, errorMessage)
-			gw.handleFailureStats(errorMessage, "webhook", authCtx)
+			gw.handleFailureStats(errorMessage, reason, "webhook", authCtx)
 		},
 		func(writeKey string) (*gwtypes.AuthRequestContext, error) {
 			authCtx := gw.authRequestContextForWriteKey(writeKey)

--- a/gateway/internal/stats/stats.go
+++ b/gateway/internal/stats/stats.go
@@ -3,9 +3,9 @@ package stats
 import (
 	"strings"
 
-	"github.com/samber/lo"
-
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
+	"github.com/samber/lo"
 )
 
 type SourceStat struct {
@@ -19,7 +19,8 @@ type SourceStat struct {
 	Version       string
 	SourceDefName string
 
-	reason string
+	reason        gwtypes.StatReason
+	droppedReason gwtypes.StatReason
 
 	requests struct {
 		total int
@@ -44,10 +45,11 @@ func (ss *SourceStat) RequestSucceeded() {
 	ss.requests.succeeded++
 }
 
-// RequestDropped increments the requests total & dropped counters by one
-func (ss *SourceStat) RequestDropped() {
+// RequestDropped increments the requests total & dropped counters by one, and records why the request was dropped
+func (ss *SourceStat) RequestDropped(reason gwtypes.StatReason) {
 	ss.requests.total++
 	ss.requests.dropped++
+	ss.droppedReason = reason
 }
 
 // RequestSuppressed increments the requests total & suppressed counters by one
@@ -57,7 +59,7 @@ func (ss *SourceStat) RequestSuppressed() {
 }
 
 // RequestFailed increments the requests total & failed counters by one
-func (ss *SourceStat) RequestFailed(reason string) {
+func (ss *SourceStat) RequestFailed(reason gwtypes.StatReason) {
 	ss.requests.total++
 	ss.requests.failed++
 	ss.reason = reason
@@ -72,7 +74,7 @@ func (ss *SourceStat) RequestEventsSucceeded(num int) {
 }
 
 // RequestEventsFailed increments the requests total & failed counters by one, and the events total & failed counters by num
-func (ss *SourceStat) RequestEventsFailed(num int, reason string) {
+func (ss *SourceStat) RequestEventsFailed(num int, reason gwtypes.StatReason) {
 	ss.requests.total++
 	ss.requests.failed++
 	ss.events.failed += num
@@ -87,7 +89,7 @@ func (ss *SourceStat) EventsSuccess(num int) {
 }
 
 // EventsFailed increments the events total & failed counters by num
-func (ss *SourceStat) EventsFailed(num int, reason string) {
+func (ss *SourceStat) EventsFailed(num int, reason gwtypes.StatReason) {
 	ss.events.failed += num
 	ss.events.total += num
 	ss.reason = reason
@@ -111,14 +113,18 @@ func (ss *SourceStat) Report(s stats.Stats) {
 	}
 
 	failedTags := lo.Assign(tags)
-	if ss.reason != "" {
-		failedTags["reason"] = ss.reason
+	if ss.reason != nil {
+		failedTags["reason"] = ss.reason.Value()
+	}
+	droppedTags := lo.Assign(tags)
+	if ss.droppedReason != nil {
+		droppedTags["reason"] = ss.droppedReason.Value()
 	}
 	if ss.requests.total > 0 {
 		s.NewTaggedStat("gateway.write_key_requests", stats.CountType, tags).Count(ss.requests.total)
 		s.NewTaggedStat("gateway.write_key_successful_requests", stats.CountType, tags).Count(ss.requests.succeeded)
 		s.NewTaggedStat("gateway.write_key_failed_requests", stats.CountType, failedTags).Count(ss.requests.failed)
-		s.NewTaggedStat("gateway.write_key_dropped_requests", stats.CountType, tags).Count(ss.requests.dropped)
+		s.NewTaggedStat("gateway.write_key_dropped_requests", stats.CountType, droppedTags).Count(ss.requests.dropped)
 		s.NewTaggedStat("gateway.write_key_suppressed_requests", stats.CountType, tags).Count(ss.requests.suppressed)
 	}
 	if ss.events.total > 0 {

--- a/gateway/internal/stats/stats.go
+++ b/gateway/internal/stats/stats.go
@@ -3,9 +3,11 @@ package stats
 import (
 	"strings"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
-	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
 	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
 )
 
 type SourceStat struct {

--- a/gateway/internal/stats/stats_test.go
+++ b/gateway/internal/stats/stats_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	trand "github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReport(t *testing.T) {
@@ -40,7 +40,7 @@ func TestReport(t *testing.T) {
 
 		randInt = 1 + newRand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
-			sourceStat.RequestDropped()
+			sourceStat.RequestDropped(gwtypes.ReasonRateLimit)
 		}
 		counterMap[sourceTag].dropped += randInt
 		counterMap[sourceTag].total += randInt
@@ -54,7 +54,7 @@ func TestReport(t *testing.T) {
 
 		randInt = 1 + newRand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
-			sourceStat.RequestFailed("reason")
+			sourceStat.RequestFailed(gwtypes.ReasonInvalidJSON)
 		}
 		counterMap[sourceTag].failed += randInt
 		counterMap[sourceTag].total += randInt
@@ -70,7 +70,7 @@ func TestReport(t *testing.T) {
 
 		randInt = 1 + newRand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
-			sourceStat.RequestEventsFailed(10, "reason")
+			sourceStat.RequestEventsFailed(10, gwtypes.ReasonInvalidJSON)
 		}
 		counterMap[sourceTag].eventsFailed += randInt * 10
 		counterMap[sourceTag].eventsTotal += randInt * 10
@@ -106,7 +106,19 @@ func TestReport(t *testing.T) {
 			"reqType":       statMap[sourceTag].ReqType,
 			"sourceType":    statMap[sourceTag].SourceType,
 			"sdkVersion":    statMap[sourceTag].Version,
-			"reason":        "reason",
+			"reason":        gwtypes.ReasonInvalidJSON.Value(),
+			"sourceDefName": strings.ToLower(statMap[sourceTag].SourceDefName),
+		}
+		// a drop now carries its own reason, kept apart from the failure reason: one SourceStat collects both
+		droppedTags := map[string]string{
+			"source":        statMap[sourceTag].Source,
+			"sourceID":      statMap[sourceTag].SourceID,
+			"workspaceId":   statMap[sourceTag].WorkspaceID,
+			"writeKey":      statMap[sourceTag].WriteKey,
+			"reqType":       statMap[sourceTag].ReqType,
+			"sourceType":    statMap[sourceTag].SourceType,
+			"sdkVersion":    statMap[sourceTag].Version,
+			"reason":        gwtypes.ReasonRateLimit.Value(),
 			"sourceDefName": strings.ToLower(statMap[sourceTag].SourceDefName),
 		}
 		require.Equal(t,
@@ -127,7 +139,7 @@ func TestReport(t *testing.T) {
 			float64(counterMap[sourceTag].dropped),
 			statsStore.Get(
 				"gateway.write_key_dropped_requests",
-				tags,
+				droppedTags,
 			).LastValue(),
 		)
 		require.Equal(t,

--- a/gateway/internal/stats/stats_test.go
+++ b/gateway/internal/stats/stats_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	trand "github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReport(t *testing.T) {

--- a/gateway/types/reason.go
+++ b/gateway/types/reason.go
@@ -106,6 +106,16 @@ var (
 
 	ReasonSourceTransformerNonSuccessResponse StatReason = newReason(response.SourceTransformerNonSuccessResponse)
 	ReasonSourceTransformerResponseError      StatReason = newReason(response.SourceTransformerResponseError)
+
+	// Reasons for the webhook batch transformer's own failures. The first four keep the strings those sites reported
+	// before; the rest replace a raw error message, which is logged at each of them instead.
+	ReasonInOutMismatch            StatReason = newReason("in out mismatch")
+	ReasonBatchResponseError       StatReason = newReason("batch response error")
+	ReasonMarshalError             StatReason = newReason("marshal error")
+	ReasonEnqueueInGatewayFailed   StatReason = newReason("enqueueInGateway failed")
+	ReasonSourceTransformerAdapter StatReason = newReason("source transformer adapter")
+	ReasonSourceTransformerURL     StatReason = newReason("source transformer url")
+	ReasonTransformerEventBuild    StatReason = newReason("transformer event build")
 )
 
 // Reasons introduced with StatReason, at sites that reported a raw error message before. The message itself is logged

--- a/gateway/types/reason.go
+++ b/gateway/types/reason.go
@@ -1,0 +1,121 @@
+package types
+
+import (
+	"slices"
+
+	"github.com/rudderlabs/rudder-server/gateway/response"
+)
+
+// StatReason is the reason a request did not succeed, as reported on the per-source stats.
+//
+// It is a closed set. Every value below becomes a Prometheus label, so an open one - an error message, say, which may
+// be formatted - would be unbounded cardinality. The interface is sealed by the unexported protected method: a caller
+// outside this package can hold a StatReason and read its Value, but cannot bring a new one into existence. That is
+// what lets a consumer of StatReporter switch over the set exhaustively instead of matching strings, and what makes a
+// reason added here a compile-visible gap in that switch rather than a silent fallthrough.
+//
+// Where no bounded reason fits, report the closest one and log the underlying error: the text belongs in the logs,
+// where it stays searchable, not in a label.
+type StatReason interface {
+	protected()
+	Value() string
+}
+
+type statReason struct{ v string }
+
+func (r *statReason) protected()    {}
+func (r *statReason) Value() string { return r.v }
+
+// Reasons returns every declared reason. A consumer outside this package uses it to check, in a test, that it still
+// handles the whole set - so a reason added here surfaces as a failure there rather than as an unmapped value in
+// production. The slice is a copy; the reasons themselves are immutable.
+func Reasons() []StatReason {
+	return slices.Clone(allReasons)
+}
+
+var allReasons []StatReason
+
+// StatReasonForMessage resolves one of this gateway's own error messages to the reason declared for it. Several
+// internal errors are built as errors.New(response.X), so the message is already the bounded identifier - this maps it
+// back to the declared value rather than letting the message reach a label directly. It reports false for anything
+// else, which the caller should report under a catch-all reason and log.
+func StatReasonForMessage(v string) (StatReason, bool) {
+	r, ok := reasonsByValue[v]
+	return r, ok
+}
+
+var reasonsByValue = map[string]StatReason{}
+
+// newReason declares a reason and registers it. Every reason below is built with it, which is what makes Reasons()
+// complete without a second list to keep in step.
+func newReason(v string) StatReason {
+	r := &statReason{v: v}
+	allReasons = append(allReasons, r)
+	reasonsByValue[v] = r
+	return r
+}
+
+// Reasons a request was dropped rather than failed: it was turned away deliberately, not broken.
+var (
+	// ReasonRateLimit marks a request refused because the source is over its limit. It is the reason an operator
+	// alerts on to find a source losing data continuously, so report it only where a rate limit is what happened.
+	ReasonRateLimit StatReason = newReason("rate limit")
+)
+
+// Reasons a request failed. The values mirror the strings these sites reported before StatReason existed, so the
+// series they produce are unchanged.
+var (
+	ReasonNoWriteKeyInBasicAuth   StatReason = newReason(response.NoWriteKeyInBasicAuth)
+	ReasonNoWriteKeyInQueryParams StatReason = newReason(response.NoWriteKeyInQueryParams)
+	ReasonInvalidWriteKey         StatReason = newReason(response.InvalidWriteKey)
+	ReasonInvalidSourceID         StatReason = newReason(response.InvalidSourceID)
+	ReasonNoSourceIDInHeader      StatReason = newReason(response.NoSourceIdInHeader)
+	ReasonSourceDisabled          StatReason = newReason(response.SourceDisabled)
+	ReasonNoDestinationIDInHeader StatReason = newReason(response.NoDestinationIDInHeader)
+	ReasonInvalidDestinationID    StatReason = newReason(response.InvalidDestinationID)
+	ReasonDestinationDisabled     StatReason = newReason(response.DestinationDisabled)
+
+	// ReasonAuthenticatingWebhookRequest marks a webhook request whose write key could not be looked up at all, as
+	// opposed to one looked up and found invalid.
+	ReasonAuthenticatingWebhookRequest StatReason = newReason(response.ErrAuthenticatingWebhookRequest)
+	ReasonInvalidReplaySource          StatReason = newReason(response.InvalidReplaySource)
+	// ReasonInvalidRequestContext marks a request that reached a handler without the context a middleware should
+	// have put on it. It is a bug in the middleware chain, not something the caller did.
+	ReasonInvalidRequestContext StatReason = newReason("invalid request context")
+
+	// ReasonWriteKeyNotFound and ReasonWriteKeyMissingFromQuery report the same conditions as ReasonInvalidWriteKey
+	// and ReasonNoWriteKeyInQueryParams, but from the sites that tagged them with these shorter strings instead of
+	// the wire message. Kept distinct so the existing series keep their values; worth collapsing into one reason
+	// each, in a change that is allowed to move them.
+	ReasonWriteKeyNotFound         StatReason = newReason("invalidWriteKey")
+	ReasonWriteKeyMissingFromQuery StatReason = newReason("NoWriteKeyInQueryParams")
+
+	ReasonEmptyBatchPayload      StatReason = newReason(response.EmptyBatchPayload)
+	ReasonNonIdentifiableRequest StatReason = newReason(response.NonIdentifiableRequest)
+	ReasonInvalidRequestMethod   StatReason = newReason(response.InvalidRequestMethod)
+	ReasonRequestBodyNil         StatReason = newReason(response.RequestBodyNil)
+	ReasonInvalidJSON            StatReason = newReason(response.InvalidJSON)
+	ReasonNotRudderEvent         StatReason = newReason(response.NotRudderEvent)
+	ReasonRequestBodyTooLarge    StatReason = newReason(response.RequestBodyTooLarge)
+	ReasonRequestBodyReadFailed  StatReason = newReason("requestBodyReadFailed")
+	ReasonStoreFailed            StatReason = newReason("storeFailed")
+
+	ReasonCouldNotParseForm      StatReason = newReason("couldNotParseForm")
+	ReasonCouldNotParseMultiform StatReason = newReason("couldNotParseMultiform")
+	ReasonCouldNotMarshal        StatReason = newReason("couldNotMarshal")
+
+	ReasonSourceTransformerNonSuccessResponse StatReason = newReason(response.SourceTransformerNonSuccessResponse)
+	ReasonSourceTransformerResponseError      StatReason = newReason(response.SourceTransformerResponseError)
+)
+
+// Reasons introduced with StatReason, at sites that reported a raw error message before. The message itself is logged
+// at each of them, so nothing is lost: it moves from a label, where it was unbounded, to a log line, where it is not.
+var (
+	// ReasonRequestProcessingFailed covers the errors building a job from a request that have no reason of their own.
+	ReasonRequestProcessingFailed StatReason = newReason("request processing failed")
+	// ReasonValidationFailed covers a message the validators rejected. Their messages come from rudder-schemas and are
+	// not ours to bound, so the reason is this and the message goes to the log.
+	ReasonValidationFailed StatReason = newReason("validation failed")
+	// ReasonMarshalEventBatchFailed marks a single event batch that could not be marshalled for storage.
+	ReasonMarshalEventBatchFailed StatReason = newReason("marshalling event batch failed")
+)

--- a/gateway/types/reason_test.go
+++ b/gateway/types/reason_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReasonsAreRegistered guards the registry against a reason declared with a bare &statReason{} literal, which
+// would be invisible to Reasons() and therefore to every consumer checking it handles the whole set.
+func TestReasonsAreRegistered(t *testing.T) {
+	require.NotEmpty(t, Reasons())
+	require.Contains(t, Reasons(), ReasonRateLimit, "ReasonRateLimit should be registered")
+	require.Contains(t, Reasons(), ReasonSourceTransformerResponseError, "the last declared reason should be registered")
+}
+
+// TestReasonValuesAreUnique guards the one failure this package cannot otherwise notice: two reasons that mean
+// different things but report the same string merge into a single Prometheus series, and every query over them is
+// quietly wrong from then on.
+func TestReasonValuesAreUnique(t *testing.T) {
+	byValue := make(map[string]StatReason, len(Reasons()))
+	for _, r := range Reasons() {
+		require.NotEmpty(t, r.Value(), "a reason with an empty value would report as an absent label")
+		_, duplicate := byValue[r.Value()]
+		require.False(t, duplicate, "two distinct reasons both report %q", r.Value())
+		byValue[r.Value()] = r
+	}
+}
+
+// TestReasonsSurviveCopy checks that Reasons() hands out a copy: a consumer that sorts or truncates the slice must not
+// be able to disturb the registry every other consumer reads.
+func TestReasonsSurviveCopy(t *testing.T) {
+	before := len(Reasons())
+	got := Reasons()
+	clear(got)
+	require.Len(t, Reasons(), before)
+	require.NotNil(t, Reasons()[0])
+}

--- a/gateway/types/types.go
+++ b/gateway/types/types.go
@@ -57,7 +57,11 @@ func (arctx *AuthRequestContext) SourceTag() string {
 
 type StatReporter interface {
 	Report(s stats.Stats)
-	RequestFailed(errMsg string)
-	RequestDropped()
+	// RequestFailed reports a request that broke, with the reason it broke. The reason is a closed set (see
+	// StatReason) so that an implementation can switch over it rather than match strings.
+	RequestFailed(reason StatReason)
+	// RequestDropped reports a request that was turned away deliberately, with the reason it was turned away - a rate
+	// limit, say, which an implementation may want to tell apart from a failure.
+	RequestDropped(reason StatReason)
 	RequestSucceeded()
 }

--- a/gateway/webhook/auth/auth.go
+++ b/gateway/webhook/auth/auth.go
@@ -12,12 +12,12 @@ import (
 var ErrSourceNotFound = errors.New("source not found")
 
 type WebhookAuth struct {
-	onFailure             func(w http.ResponseWriter, r *http.Request, errorMessage string, authCtx *gwtypes.AuthRequestContext)
+	onFailure             func(w http.ResponseWriter, r *http.Request, errorMessage string, reason gwtypes.StatReason, authCtx *gwtypes.AuthRequestContext)
 	authReqCtxForWriteKey func(writeKey string) (*gwtypes.AuthRequestContext, error)
 }
 
 func NewWebhookAuth(
-	onFailure func(w http.ResponseWriter, r *http.Request, errorMessage string, authCtx *gwtypes.AuthRequestContext),
+	onFailure func(w http.ResponseWriter, r *http.Request, errorMessage string, reason gwtypes.StatReason, authCtx *gwtypes.AuthRequestContext),
 	authReqCtxForWriteKey func(writeKey string) (*gwtypes.AuthRequestContext, error),
 ) *WebhookAuth {
 	return &WebhookAuth{
@@ -37,24 +37,24 @@ func (wa *WebhookAuth) AuthHandler(next http.HandlerFunc) http.HandlerFunc {
 			writeKey, _, _ = r.BasicAuth()
 		}
 		if writeKey == "" {
-			wa.onFailure(w, r, response.NoWriteKeyInQueryParams, nil)
+			wa.onFailure(w, r, response.NoWriteKeyInQueryParams, gwtypes.ReasonNoWriteKeyInQueryParams, nil)
 			return
 		}
 		arctx, err := wa.authReqCtxForWriteKey(writeKey)
 		if err != nil {
 			if errors.Is(err, ErrSourceNotFound) {
-				wa.onFailure(w, r, response.InvalidWriteKey, arctx)
+				wa.onFailure(w, r, response.InvalidWriteKey, gwtypes.ReasonInvalidWriteKey, arctx)
 				return
 			}
-			wa.onFailure(w, r, response.ErrAuthenticatingWebhookRequest, arctx)
+			wa.onFailure(w, r, response.ErrAuthenticatingWebhookRequest, gwtypes.ReasonAuthenticatingWebhookRequest, arctx)
 			return
 		}
 		if arctx.SourceCategory != "webhook" {
-			wa.onFailure(w, r, response.InvalidWriteKey, arctx)
+			wa.onFailure(w, r, response.InvalidWriteKey, gwtypes.ReasonInvalidWriteKey, arctx)
 			return
 		}
 		if !arctx.SourceEnabled {
-			wa.onFailure(w, r, response.SourceDisabled, arctx)
+			wa.onFailure(w, r, response.SourceDisabled, gwtypes.ReasonSourceDisabled, arctx)
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), gwtypes.CtxParamAuthRequestContext, arctx)))

--- a/gateway/webhook/auth/auth_test.go
+++ b/gateway/webhook/auth/auth_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewWebhookAuth(t *testing.T) {
 	tests := []struct {
 		name                      string
-		mockOnFailure             func(w http.ResponseWriter, r *http.Request, errorMessage string, authCtx *gwtypes.AuthRequestContext)
+		mockOnFailure             func(w http.ResponseWriter, r *http.Request, errorMessage string, reason gwtypes.StatReason, authCtx *gwtypes.AuthRequestContext)
 		mockAuthReqCtxForWriteKey func(writeKey string) (*gwtypes.AuthRequestContext, error)
 		writeKey                  string
 		expectedResponseCode      int
@@ -25,7 +25,7 @@ func TestNewWebhookAuth(t *testing.T) {
 	}{
 		{
 			name: "valid write key",
-			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ *gwtypes.AuthRequestContext) {
+			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ gwtypes.StatReason, _ *gwtypes.AuthRequestContext) {
 				t.Error("onFailure should not be called for a valid write key")
 			},
 			mockAuthReqCtxForWriteKey: func(writeKey string) (*gwtypes.AuthRequestContext, error) {
@@ -40,7 +40,7 @@ func TestNewWebhookAuth(t *testing.T) {
 		},
 		{
 			name: "invalid write key",
-			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ *gwtypes.AuthRequestContext) {
+			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ gwtypes.StatReason, _ *gwtypes.AuthRequestContext) {
 				http.Error(w, errorMessage, http.StatusUnauthorized)
 			},
 			mockAuthReqCtxForWriteKey: func(writeKey string) (*gwtypes.AuthRequestContext, error) {
@@ -52,7 +52,7 @@ func TestNewWebhookAuth(t *testing.T) {
 		},
 		{
 			name: "empty write key",
-			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ *gwtypes.AuthRequestContext) {
+			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ gwtypes.StatReason, _ *gwtypes.AuthRequestContext) {
 				http.Error(w, errorMessage, http.StatusUnauthorized)
 			},
 			mockAuthReqCtxForWriteKey: func(writeKey string) (*gwtypes.AuthRequestContext, error) {
@@ -64,7 +64,7 @@ func TestNewWebhookAuth(t *testing.T) {
 		},
 		{
 			name: "disabled source",
-			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ *gwtypes.AuthRequestContext) {
+			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ gwtypes.StatReason, _ *gwtypes.AuthRequestContext) {
 				http.Error(w, errorMessage, http.StatusForbidden)
 			},
 			mockAuthReqCtxForWriteKey: func(writeKey string) (*gwtypes.AuthRequestContext, error) {
@@ -79,7 +79,7 @@ func TestNewWebhookAuth(t *testing.T) {
 		},
 		{
 			name: "error getting auth context",
-			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ *gwtypes.AuthRequestContext) {
+			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ gwtypes.StatReason, _ *gwtypes.AuthRequestContext) {
 				http.Error(w, errorMessage, http.StatusInternalServerError)
 			},
 			mockAuthReqCtxForWriteKey: func(writeKey string) (*gwtypes.AuthRequestContext, error) {
@@ -91,7 +91,7 @@ func TestNewWebhookAuth(t *testing.T) {
 		},
 		{
 			name: "source category not webhook",
-			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ *gwtypes.AuthRequestContext) {
+			mockOnFailure: func(w http.ResponseWriter, r *http.Request, errorMessage string, _ gwtypes.StatReason, _ *gwtypes.AuthRequestContext) {
 				http.Error(w, errorMessage, http.StatusBadRequest)
 			},
 			mockAuthReqCtxForWriteKey: func(writeKey string) (*gwtypes.AuthRequestContext, error) {

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -106,7 +106,7 @@ type batchWebhookTransformerT struct {
 
 type batchTransformerOption func(bt *batchWebhookTransformerT)
 
-func (webhook *HandleT) failRequest(w http.ResponseWriter, r *http.Request, reason string, code int) {
+func (webhook *HandleT) failRequest(w http.ResponseWriter, r *http.Request, errorMessage string, code int) {
 	statusCode := http.StatusBadRequest
 	if code != 0 {
 		statusCode = code
@@ -115,8 +115,8 @@ func (webhook *HandleT) failRequest(w http.ResponseWriter, r *http.Request, reas
 		logger.NewStringField("ip", kithttputil.GetRequestIP(r)),
 		logger.NewStringField("path", r.URL.Path),
 		logger.NewIntField("code", int64(code)),
-		logger.NewStringField("reason", reason))
-	http.Error(w, reason, statusCode)
+		logger.NewStringField("errorMessage", errorMessage))
+	http.Error(w, errorMessage, statusCode)
 }
 
 func (wb *HandleT) IsGetAndNotAllow(reqMethod, sourceDefName string) bool {
@@ -328,7 +328,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			bt.webhook.logger.Errorn("webhook source transformation failed",
 				obskit.SourceType(breq.sourceType),
 				obskit.Error(err))
-			bt.webhook.recordWebhookErrors(breq.sourceType, err.Error(), breq.batchRequest, response.GetErrorStatusCode(err.Error()))
+			bt.webhook.recordWebhookErrors(breq.sourceType, gwtypes.ReasonSourceTransformerAdapter, breq.batchRequest, response.GetErrorStatusCode(err.Error()))
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: response.GetErrorStatusCode(response.GatewayTimeout), Err: response.GetStatus(response.GatewayTimeout)}
 			}
@@ -342,7 +342,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			bt.webhook.logger.Errorn("webhook source transformation failed",
 				obskit.SourceType(breq.sourceType),
 				obskit.Error(err))
-			bt.webhook.recordWebhookErrors(breq.sourceType, err.Error(), breq.batchRequest, response.GetErrorStatusCode(response.ServiceUnavailable))
+			bt.webhook.recordWebhookErrors(breq.sourceType, gwtypes.ReasonSourceTransformerURL, breq.batchRequest, response.GetErrorStatusCode(response.ServiceUnavailable))
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: response.GetErrorStatusCode(response.ServiceUnavailable), Err: response.GetStatus(response.ServiceUnavailable)}
 			}
@@ -361,22 +361,26 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				eventRequest, err = prepareTransformerEventRequestV2(req.request)
 			}
 
+			// The reason is set beside the error rather than read back off its message, so it stays a declared value
+			// however the error is built. It starts as the build failure above, if there was one.
+			reason := gwtypes.ReasonTransformerEventBuild
 			if err == nil {
 				eventRequest, err = misc.SanitizeJSON(eventRequest)
 				if err != nil {
 					bt.webhook.logger.Errorn("invalid payload", obskit.Error(err), obskit.SourceType(breq.sourceType), obskit.SourceID(req.sourceID))
-					err = errors.New(response.InvalidJSON)
+					err, reason = errors.New(response.InvalidJSON), gwtypes.ReasonInvalidJSON
 				}
 			}
 
 			if err == nil && !json.Valid(eventRequest) {
-				err = errors.New(response.InvalidJSON)
+				err, reason = errors.New(response.InvalidJSON), gwtypes.ReasonInvalidJSON
 			}
 			if err == nil && len(eventRequest) > bt.webhook.config.maxReqSize.Load() {
-				err = errors.New(response.RequestBodyTooLarge)
+				err, reason = errors.New(response.RequestBodyTooLarge), gwtypes.ReasonRequestBodyTooLarge
 			}
 			if err == nil {
 				payload, err = sourceTransformAdapter.getTransformerEvent(req.authContext, eventRequest)
+				reason = gwtypes.ReasonTransformerEventBuild
 			}
 
 			if err != nil {
@@ -384,7 +388,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 					obskit.SourceType(req.sourceType),
 					obskit.SourceID(req.sourceID),
 					obskit.Error(err))
-				bt.webhook.countWebhookErrors(breq.sourceType, req.authContext, err.Error(), response.GetErrorStatusCode(err.Error()), 1)
+				bt.webhook.countWebhookErrors(breq.sourceType, req.authContext, reason, response.GetErrorStatusCode(err.Error()), 1)
 				req.done <- transformerResponse{Err: response.GetStatus(err.Error()), StatusCode: response.GetErrorStatusCode(err.Error())}
 				continue
 			}
@@ -411,16 +415,16 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 		// stats
 		bt.stats.sourceStats[breq.sourceType].sourceTransform.Since(transformStart)
 
-		var reason string
+		var reason gwtypes.StatReason
 		if batchResponse.batchError == nil && len(batchResponse.responses) != len(payloadArr) {
 			batchResponse.batchError = errors.New("webhook batch transform response events size does not equal sent events size")
-			reason = "in out mismatch"
+			reason = gwtypes.ReasonInOutMismatch
 			bt.webhook.logger.Errorn("webhook batch transform response events size does not equal sent events size",
 				obskit.Error(batchResponse.batchError))
 		}
 		if batchResponse.batchError != nil {
-			if reason == "" {
-				reason = "batch response error"
+			if reason == nil {
+				reason = gwtypes.ReasonBatchResponseError
 			}
 			statusCode := http.StatusInternalServerError
 			if batchResponse.statusCode != 0 {
@@ -458,14 +462,15 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 		for idx, resp := range batchResponse.responses {
 			webRequest := webRequests[idx]
 			if resp.Err == "" && resp.Output != nil {
-				var errMessage, reason string
+				var errMessage string
+				var reason gwtypes.StatReason
 				outputPayload, err := jsonrs.Marshal(resp.Output)
 				if err != nil {
 					errMessage = response.SourceTransformerInvalidOutputFormatInResponse
-					reason = "marshal error"
+					reason = gwtypes.ReasonMarshalError
 				} else {
 					errMessage = bt.webhook.enqueueInGateway(webRequest, outputPayload)
-					reason = "enqueueInGateway failed"
+					reason = gwtypes.ReasonEnqueueInGatewayFailed
 				}
 				if errMessage != "" {
 					bt.webhook.logger.Errorn("webhook source transformation failed",
@@ -483,7 +488,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				}
 				failedWebhookPayloads = append(failedWebhookPayloads, &model.FailedWebhookPayload{RequestContext: webRequest.authContext, Payload: payloadArr[idx], SourceType: breq.sourceType, Reason: failureReason})
 				bt.webhook.logger.Errorn("webhook source transformation failed", obskit.SourceType(breq.sourceType), logger.NewStringField("errorMsg", resp.Err), logger.NewIntField("statusCode", int64(resp.StatusCode)))
-				bt.webhook.countWebhookErrors(breq.sourceType, webRequest.authContext, getWebhookFailureReason(resp.Err, resp.StatusCode).Value(), resp.StatusCode, 1)
+				bt.webhook.countWebhookErrors(breq.sourceType, webRequest.authContext, getWebhookFailureReason(resp.Err, resp.StatusCode), resp.StatusCode, 1)
 			}
 			webRequest.done <- resp
 		}
@@ -495,15 +500,16 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	}
 }
 
-func (bt *batchWebhookTransformerT) getWebhookFailureReason(errMessage, reason string) string {
-	if reason == "enqueueInGateway failed" {
+// getWebhookFailureReason refines the reason for a payload the gateway refused to enqueue. The gateway answers with a
+// message rather than a reason, so the two it can give that mean something more specific than "the enqueue failed" are
+// recognised here. A rate limit reports ReasonRateLimit, the same value every other rate limit reports.
+func (bt *batchWebhookTransformerT) getWebhookFailureReason(errMessage string, reason gwtypes.StatReason) gwtypes.StatReason {
+	if reason == gwtypes.ReasonEnqueueInGatewayFailed {
 		switch errMessage {
 		case response.TooManyRequests:
-			return response.TooManyRequests
+			return gwtypes.ReasonRateLimit
 		case response.RequestBodyTooLarge:
-			return response.RequestBodyTooLarge
-		default:
-			return reason
+			return gwtypes.ReasonRequestBodyTooLarge
 		}
 	}
 	return reason
@@ -557,18 +563,18 @@ func (webhook *HandleT) Shutdown() error {
 	return webhook.backgroundWait()
 }
 
-func (webhook *HandleT) countWebhookErrors(sourceType string, arctx *gwtypes.AuthRequestContext, reason string, statusCode, count int) {
+func (webhook *HandleT) countWebhookErrors(sourceType string, arctx *gwtypes.AuthRequestContext, reason gwtypes.StatReason, statusCode, count int) {
 	webhook.stats.NewTaggedStat("webhook_num_errors", stats.CountType, stats.Tags{
 		"writeKey":    arctx.WriteKey,
 		"workspaceId": arctx.WorkspaceID,
 		"sourceID":    arctx.SourceID,
 		"statusCode":  strconv.Itoa(statusCode),
 		"sourceType":  sourceType,
-		"reason":      reason,
+		"reason":      reason.Value(),
 	}).Count(count)
 }
 
-func (webhook *HandleT) recordWebhookErrors(sourceType, reason string, reqs []*webhookT, statusCode int) {
+func (webhook *HandleT) recordWebhookErrors(sourceType string, reason gwtypes.StatReason, reqs []*webhookT, statusCode int) {
 	authCtxs := lo.SliceToMap(reqs, func(request *webhookT) (string, *gwtypes.AuthRequestContext) {
 		return request.authContext.WriteKey, request.authContext
 	})

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -141,7 +141,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(strings.ToLower(contentType), "application/x-www-form-urlencoded") {
 		if err := r.ParseForm(); err != nil {
 			stat := webhook.statReporterCreator(arctx, reqType)
-			stat.RequestFailed("couldNotParseForm")
+			stat.RequestFailed(gwtypes.ReasonCouldNotParseForm)
 			stat.Report(webhook.stats)
 
 			webhook.failRequest(
@@ -157,7 +157,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	} else if strings.Contains(strings.ToLower(contentType), "multipart/form-data") {
 		if err := r.ParseMultipartForm(32 << 20); err != nil {
 			stat := webhook.statReporterCreator(arctx, reqType)
-			stat.RequestFailed("couldNotParseMultiform")
+			stat.RequestFailed(gwtypes.ReasonCouldNotParseMultiform)
 			stat.Report(webhook.stats)
 
 			webhook.failRequest(
@@ -179,7 +179,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		jsonByte, err = jsonrs.Marshal(multipartForm)
 		if err != nil {
 			stat := webhook.statReporterCreator(arctx, reqType)
-			stat.RequestFailed("couldNotMarshal")
+			stat.RequestFailed(gwtypes.ReasonCouldNotMarshal)
 			stat.Report(webhook.stats)
 			webhook.failRequest(
 				w,
@@ -194,7 +194,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		jsonByte, err = jsonrs.Marshal(postFrom)
 		if err != nil {
 			stat := webhook.statReporterCreator(arctx, reqType)
-			stat.RequestFailed("couldNotMarshal")
+			stat.RequestFailed(gwtypes.ReasonCouldNotMarshal)
 			stat.Report(webhook.stats)
 			webhook.failRequest(
 				w,
@@ -248,10 +248,12 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 			logger.NewStringField("error", resp.Err))
 		http.Error(w, resp.Err, code)
 		if resp.StatusCode == http.StatusTooManyRequests {
-			ss.RequestDropped()
+			// A 429 is a rate limit whoever imposed it - the gateway the payload was enqueued into, or the source
+			// transformer answering for the source. The distinction is not available here, and either way the source
+			// is losing data to a limit, which is what a consumer of this reason acts on.
+			ss.RequestDropped(gwtypes.ReasonRateLimit)
 		} else {
-			failureReason := getWebhookFailureReason(resp.Err, resp.StatusCode)
-			ss.RequestFailed(failureReason)
+			ss.RequestFailed(getWebhookFailureReason(resp.Err, resp.StatusCode))
 		}
 		ss.Report(webhook.stats)
 		return
@@ -271,16 +273,14 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	ss.Report(webhook.stats)
 }
 
-func getWebhookFailureReason(errMsg string, statusCode int) string {
+func getWebhookFailureReason(errMsg string, statusCode int) gwtypes.StatReason {
 	switch {
 	case errMsg == response.RequestBodyTooLarge:
-		return response.RequestBodyTooLarge
+		return gwtypes.ReasonRequestBodyTooLarge
 	case statusCode != 0:
-		return response.SourceTransformerNonSuccessResponse
-	case errMsg != "":
-		return response.SourceTransformerResponseError
+		return gwtypes.ReasonSourceTransformerNonSuccessResponse
 	default:
-		return response.SourceTransformerResponseError
+		return gwtypes.ReasonSourceTransformerResponseError
 	}
 }
 
@@ -483,7 +483,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				}
 				failedWebhookPayloads = append(failedWebhookPayloads, &model.FailedWebhookPayload{RequestContext: webRequest.authContext, Payload: payloadArr[idx], SourceType: breq.sourceType, Reason: failureReason})
 				bt.webhook.logger.Errorn("webhook source transformation failed", obskit.SourceType(breq.sourceType), logger.NewStringField("errorMsg", resp.Err), logger.NewIntField("statusCode", int64(resp.StatusCode)))
-				bt.webhook.countWebhookErrors(breq.sourceType, webRequest.authContext, getWebhookFailureReason(resp.Err, resp.StatusCode), resp.StatusCode, 1)
+				bt.webhook.countWebhookErrors(breq.sourceType, webRequest.authContext, getWebhookFailureReason(resp.Err, resp.StatusCode).Value(), resp.StatusCode, 1)
 			}
 			webRequest.done <- resp
 		}

--- a/gateway/webhook/webhookTransformer.go
+++ b/gateway/webhook/webhookTransformer.go
@@ -202,10 +202,10 @@ type transformerBatchResponseT struct {
 	statusCode int
 }
 
-func (bt *batchWebhookTransformerT) markResponseFail(reason string) transformerResponse {
-	statusCode := response.GetErrorStatusCode(reason)
+func (bt *batchWebhookTransformerT) markResponseFail(errorMessage string) transformerResponse {
+	statusCode := response.GetErrorStatusCode(errorMessage)
 	resp := transformerResponse{
-		Err:        response.GetStatus(reason),
+		Err:        response.GetStatus(errorMessage),
 		StatusCode: statusCode,
 	}
 	bt.stats.failedStat.Count(1)

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -388,7 +388,7 @@ func TestRecordWebhookErrors(t *testing.T) {
 		{authContext: &gwtypes.AuthRequestContext{WriteKey: "w1", SourceID: "sourceID1", WorkspaceID: "workspaceID1", SourceCategory: "webhook1"}},
 	}
 
-	webhookHandler.recordWebhookErrors("cio", "err1", reqs, 400)
+	webhookHandler.recordWebhookErrors("cio", gwtypes.ReasonBatchResponseError, reqs, 400)
 
 	m := statsStore.Get("webhook_num_errors", stats.Tags{
 		"writeKey":    "w1",
@@ -396,7 +396,7 @@ func TestRecordWebhookErrors(t *testing.T) {
 		"sourceID":    "sourceID1",
 		"statusCode":  "400",
 		"sourceType":  "cio",
-		"reason":      "err1",
+		"reason":      gwtypes.ReasonBatchResponseError.Value(),
 	})
 	require.EqualValues(t, m.LastValue(), 3)
 	m = statsStore.Get("webhook_num_errors", stats.Tags{
@@ -405,7 +405,7 @@ func TestRecordWebhookErrors(t *testing.T) {
 		"sourceID":    "sourceID2",
 		"statusCode":  "400",
 		"sourceType":  "cio",
-		"reason":      "err1",
+		"reason":      gwtypes.ReasonBatchResponseError.Value(),
 	})
 	require.EqualValues(t, m.LastValue(), 2)
 	m = statsStore.Get("webhook_num_errors", stats.Tags{
@@ -414,7 +414,7 @@ func TestRecordWebhookErrors(t *testing.T) {
 		"sourceID":    "sourceID3",
 		"statusCode":  "400",
 		"sourceType":  "cio",
-		"reason":      "err1",
+		"reason":      gwtypes.ReasonBatchResponseError.Value(),
 	})
 	require.EqualValues(t, m.LastValue(), 1)
 }


### PR DESCRIPTION
# Companion PRs

* `rudder-ingestion-svc` on `refactor/gateway-request-metrics`
  * This PR merges first: ingestion-svc cannot build against it until it is tagged.
  * https://github.com/rudderlabs/rudder-ingestion-svc/pull/693
* `rudderstack-operator` on `refactor/ingestion-svc-request-metrics`
  * https://github.com/rudderlabs/rudderstack-operator/pull/1617

## What

`gwTypes.StatReporter` reported the reason a request failed as a plain `string`, and reported a drop with no reason at all. Both now carry a `gwtypes.StatReason`: a sealed interface over a closed set of declared values, which a consumer can switch over exhaustively instead of matching on message text.

## Why

`StatReporter` is the seam another service implements to receive the outcome of a request this gateway handled — rudder-ingestion-svc runs the webhook package in-process and implements it. A `string` reason forces that implementer to match on message text, which breaks silently the moment a message is reworded. `RequestDropped()` was worse: it reported the fact of a drop and nothing else, so a consumer could not tell a rate limit from anything else, and could not alert on a source losing data to its limit.

The reason values also become Prometheus labels, and three call sites fed a raw `err.Error()` straight into one — unbounded cardinality on `gateway.write_key_failed_requests`.

## The type

`gateway/types/reason.go` declares `StatReason`, sealed by an unexported `protected()` method. A caller outside the package can hold a reason and read its `Value()`, but cannot bring a new one into existence, so the set is closed by the compiler rather than by convention.

Every reason is built through an unexported `newReason`, which registers it in two indexes. `Reasons()` returns the whole set, so a consumer can assert in its own tests that it still handles all of them — a reason added here then surfaces there as a failing test rather than as an unattributed series in production. rudder-ingestion-svc's companion PR does exactly that, and it caught four unmapped reasons during this work.

`StatReasonForMessage` resolves one of this gateway's own error messages back to the reason declared for it. Several internal errors are built as `errors.New(response.X)`, so the message is already the bounded identifier; this maps it back to the declared value rather than letting the message reach a label. It reports false for anything else, which the caller reports under a catch-all and logs.

## Changes

`RequestFailed` and `RequestDropped` take a `StatReason`. `SourceStat` follows, along with `RequestEventsFailed` and `EventsFailed`, since they share the same reason field.

Drops now carry their own reason in a field separate from the failure reason. One `SourceStat` is reused across every request for a source tag within a batch, so a batch containing both a drop and a failure would otherwise have one clobber the other.

`auth.NewWebhookAuth`'s `onFailure` callback gains a `StatReason` parameter. The existing `errorMessage` stays: it is the wire message the caller sees, which is a different thing from the reason reported on a metric, and conflating the two is what made a single string look sufficient. `handleFailureStats` likewise takes the reason from its caller instead of re-deriving it from the message; its remaining switch only picks the stat's shape.

The webhook package reports its own errors on `webhook_num_errors`, and that reason was a string too, with three callers passing `err.Error()` and the rest passing ad-hoc literals. `countWebhookErrors` and `recordWebhookErrors` now take a `StatReason`, and the batch transformer carries the reason beside the error as it builds it rather than reading it back off the message afterwards. `failRequest` and `markResponseFail` keep their string parameter, since that one is the message shown to the caller, but it is renamed from `reason` to `errorMessage` so the two are not confused again.

The three `err.Error()` sites on `SourceStat` are handled by what each one actually carries. `getJobDataFromRequest`'s error path and the message validator's both resolve through `StatReasonForMessage`, falling back to `ReasonRequestProcessingFailed` and `ReasonValidationFailed` and logging the error when they cannot. The marshalling site has no bounded message at all and reports `ReasonMarshalEventBatchFailed`, with the error logged as it already was.

## Metric impact

Every reason's `Value()` matches the string its site reported before, so existing series keep their values — with these exceptions.

`gateway.write_key_dropped_requests` gains a `reason` label. Adding a label is additive, so `sum by(...)` queries are unaffected, but the series now split by reason.

The marshalling site reports `marshalling event batch failed` instead of the marshal error's text, and the validator site reports `validation failed` for any message not declared here. Both were unbounded before, which is the cardinality fix; a stable query against either is unlikely to have existed.

On `webhook_num_errors`, the three sites that reported a raw error now report `source transformer adapter`, `source transformer url` and one of the declared build reasons — again replacing unbounded text. The literal reasons those sites already used keep their values (`in out mismatch`, `batch response error`, `marshal error`, `enqueueInGateway failed`). One value does change deliberately: a payload the gateway refused for rate limiting reported the wire message `max requests limit reached` and now reports `rate limit`, so a rate limit reads the same on every metric that names one.

Two pairs of reasons describe the same condition with different strings, because the sites reporting them always did: `invalid write key` / `invalidWriteKey`, and `failed to read writekey from query params` / `NoWriteKeyInQueryParams`. They are kept distinct so existing series keep their values, and flagged in the code as worth collapsing in a change that is allowed to move them.

## Compatibility

This is a compile-time break for anything implementing `StatReporter`, which is the intended safety net: an implementer cannot bump this dependency and silently keep reporting nothing. There are no gomock mocks of the interface to regenerate. Inside this repo the only implementer is `gateway/internal/stats.SourceStat`; outside it, rudder-ingestion-svc, whose companion PR lands with this one.

## Verification

`go vet ./...` clean. `go test ./gateway/...` passes, including the full `./gateway/` ginkgo suite. `golangci-lint` reports 0 issues and `actionlint` is clean. The `verify.yml` gates pass: `go mod tidy` leaves `go.mod` unchanged, `make mocks` produces no diff, and `make fmt` touches only the files in this PR.

## Linear Ticket

< Fixes [PIPE-3310](https://linear.app/rudderstack/issue/PIPE-3310/rudder-server-webhook-reasons) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
