### PR TITLE
fix(processor): proc destination hydration omitted destination's original id

### DIFF
--- a/processor/proc_consumer.go
+++ b/processor/proc_consumer.go
@@ -194,7 +194,7 @@ func (proc *Handle) procRebuildStage(destinationID string, in subJob) (*transfor
 		totalEvents++
 		sourceID := payload.Metadata.SourceID
 
-		// Re-hydrate the destination from live config. Config drift: a destination
+		// Hydrate the destination from live config. Config drift: a destination
 		// deleted/disabled since fan-out is dropped gracefully to a terminal status.
 		dest, ok := proc.getEnabledDestinationByID(sourceID, destinationID)
 		if !ok {
@@ -210,8 +210,10 @@ func (proc *Handle) procRebuildStage(destinationID string, in subJob) (*transfor
 			Libraries:   proc.getWorkspaceLibraries(payload.Metadata.WorkspaceID),
 			Credentials: proc.config.credentialsMap[payload.Metadata.WorkspaceID],
 		}
-		// Refresh destination metadata from the (possibly drifted) live config.
+		// Populate the destination metadata fields, which are cleared at fork time
+		// (see newForkedJob) since a forked job fans out to multiple destinations.
 		event.Metadata.DestinationID = dest.ID
+		event.Metadata.OriginalDestinationID = dest.OriginalID
 		event.Metadata.DestinationName = dest.Name
 		event.Metadata.DestinationType = dest.DestinationDefinition.Name
 		event.Metadata.DestinationDefinitionID = dest.DestinationDefinition.ID

--- a/processor/proc_consumer_test.go
+++ b/processor/proc_consumer_test.go
@@ -31,9 +31,10 @@ func newTestProcHandle() *Handle {
 
 func testDestination(id, name string, enabled bool) backendconfig.DestinationT { //nolint: unparam
 	return backendconfig.DestinationT{
-		ID:      id,
-		Name:    name,
-		Enabled: enabled,
+		ID:         id,
+		OriginalID: "orig-" + id,
+		Name:       name,
+		Enabled:    enabled,
 		DestinationDefinition: backendconfig.DestinationDefinitionT{
 			ID:   "defID-" + id,
 			Name: "WEBHOOK",
@@ -94,6 +95,7 @@ func TestProcRebuildStage(t *testing.T) {
 		ev := out.groupedEvents[key][0]
 		require.Equal(t, dstID, ev.Destination.ID)
 		require.Equal(t, dstID, ev.Metadata.DestinationID)
+		require.Equal(t, "orig-"+dstID, ev.Metadata.OriginalDestinationID)
 		require.Equal(t, "my-webhook", ev.Metadata.DestinationName)
 		require.Equal(t, "WEBHOOK", ev.Metadata.DestinationType)
 		require.Equal(t, "defID-"+dstID, ev.Metadata.DestinationDefinitionID)
@@ -127,6 +129,7 @@ func TestProcRebuildStage(t *testing.T) {
 
 		ev := out.groupedEvents[getKeyFromSourceAndDest(srcID, dstID)][0]
 		require.Equal(t, dstID, ev.Metadata.DestinationID)
+		require.Equal(t, "orig-"+dstID, ev.Metadata.OriginalDestinationID)
 		require.Equal(t, "my-webhook", ev.Metadata.DestinationName)
 		require.Equal(t, "WEBHOOK", ev.Metadata.DestinationType)
 		require.Equal(t, "defID-"+dstID, ev.Metadata.DestinationDefinitionID)

--- a/processor/proc_fork.go
+++ b/processor/proc_fork.go
@@ -74,6 +74,7 @@ func (proc *Handle) newForkedJob(event *types.TransformerEvent, forkedDestIDs []
 	// (procRebuildStage), so no single destination's identity may be baked into the payload.
 	metadata := event.Metadata
 	metadata.DestinationID = ""
+	metadata.OriginalDestinationID = ""
 	metadata.DestinationName = ""
 	metadata.DestinationType = ""
 	metadata.DestinationDefinitionID = ""

--- a/processor/proc_fork_test.go
+++ b/processor/proc_fork_test.go
@@ -99,6 +99,7 @@ func TestNewForkedJob(t *testing.T) {
 			SourceName:  "source-1",
 			// destination-specific fields must NOT leak into a multi-destination forked job
 			DestinationID:           "should-not-appear",
+			OriginalDestinationID:   "should-not-appear",
 			DestinationName:         "should-not-appear",
 			DestinationType:         "should-not-appear",
 			DestinationDefinitionID: "should-not-appear",
@@ -131,6 +132,7 @@ func TestNewForkedJob(t *testing.T) {
 	// destination-specific metadata must be stripped: a forked job fans out to multiple
 	// destinations, re-hydrated per consumer at drain time.
 	require.Empty(t, payload.Metadata.DestinationID)
+	require.Empty(t, payload.Metadata.OriginalDestinationID)
 	require.Empty(t, payload.Metadata.DestinationName)
 	require.Empty(t, payload.Metadata.DestinationType)
 	require.Empty(t, payload.Metadata.DestinationDefinitionID)


### PR DESCRIPTION
# Description

Filling Metadata.OriginalDestinationID during proc rebuild stage.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
