### PR TITLE
feat(warehouse): clickhouse v2 ddl operations

### DIFF
--- a/warehouse/integrations/clickhouse/clickhousev2.go
+++ b/warehouse/integrations/clickhouse/clickhousev2.go
@@ -6,8 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -18,11 +22,13 @@ import (
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 var (
 	errNotImplemented         = errors.New(warehouseutils.NotImplementedErrorCode)
+	errInvalidPartitionType   = errors.New("invalid partition type")
 	errAppendingCACertificate = errors.New("appending ca certificate to pool")
 )
 
@@ -191,6 +197,241 @@ func (ch *ClickhouseV2) clusterClause() string {
 		return fmt.Sprintf(`ON CLUSTER %q`, cluster)
 	}
 	return ""
+}
+
+func (ch *ClickhouseV2) CreateTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
+	sortKeyFields := []string{"received_at", "id"}
+	if tableName == warehouseutils.DiscardsTable {
+		sortKeyFields = []string{"received_at"}
+	}
+	if strings.HasPrefix(tableName, warehouseutils.CTStagingTablePrefix) {
+		sortKeyFields = []string{"id"}
+	}
+	var sqlStatement string
+	if tableName == warehouseutils.UsersTable {
+		return ch.createUsersTable(ctx, tableName, columns)
+	}
+	clusterClause := ""
+	engine := "ReplacingMergeTree"
+	engineOptions := ""
+	cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting)
+	if len(strings.TrimSpace(cluster)) > 0 {
+		clusterClause = fmt.Sprintf(`ON CLUSTER %q`, cluster)
+		engine = fmt.Sprintf(`%s%s`, "Replicated", engine)
+		engineOptions = fmt.Sprintf(`'/clickhouse/{cluster}/tables/%s/{database}/{table}', '{replica}'`, uuid.New().String())
+	}
+	var orderByClause string
+	if len(sortKeyFields) > 0 {
+		orderByClause = fmt.Sprintf(`ORDER BY %s`, getSortKeyTuple(sortKeyFields))
+	}
+
+	var partitionByClause string
+	if _, ok := columns[partitionField]; ok {
+		partitionByClause, err = ch.partitionByClause()
+		if err != nil {
+			return fmt.Errorf("getting partition by clause: %w", err)
+		}
+	}
+
+	sqlStatement = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.%q %s ( %v ) ENGINE = %s(%s) %s %s`, ch.Namespace, tableName, clusterClause, ch.ColumnsWithDataTypes(tableName, columns, sortKeyFields), engine, engineOptions, orderByClause, partitionByClause)
+
+	ch.logger.Infon("CH: Creating table in clickhouse for ch",
+		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
+		logger.NewStringField(logfield.Query, sqlStatement),
+	)
+	_, err = ch.DB.ExecContext(ctx, sqlStatement)
+	return err
+}
+
+/*
+createUsersTable creates a user's table with engine AggregatingMergeTree,
+this lets us choose aggregation logic before merging records with same user id.
+current behaviour is to replace user  properties with the latest non-null values
+*/
+func (ch *ClickhouseV2) createUsersTable(ctx context.Context, name string, columns model.TableSchema) (err error) {
+	sortKeyFields := []string{"id"}
+	notNullableColumns := []string{"received_at", "id"}
+	clusterClause := ""
+	engine := "AggregatingMergeTree"
+	engineOptions := ""
+	cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting)
+	if len(strings.TrimSpace(cluster)) > 0 {
+		clusterClause = fmt.Sprintf(`ON CLUSTER %q`, cluster)
+		engine = fmt.Sprintf(`%s%s`, "Replicated", engine)
+		engineOptions = fmt.Sprintf(`'/clickhouse/{cluster}/tables/%s/{database}/{table}', '{replica}'`, uuid.New().String())
+	}
+	partitionByClause, err := ch.partitionByClause()
+	if err != nil {
+		return fmt.Errorf("getting partition by clause: %w", err)
+	}
+
+	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.%q %s ( %v )  ENGINE = %s(%s) ORDER BY %s %s`, ch.Namespace, name, clusterClause, ch.ColumnsWithDataTypes(name, columns, notNullableColumns), engine, engineOptions, getSortKeyTuple(sortKeyFields), partitionByClause)
+	ch.logger.Infon("CH: Creating table in clickhouse for ch",
+		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
+		logger.NewStringField(logfield.Query, sqlStatement),
+	)
+	_, err = ch.DB.ExecContext(ctx, sqlStatement)
+	return err
+}
+
+// ColumnsWithDataTypes creates columns and its datatype into sql format for creating table
+func (ch *ClickhouseV2) ColumnsWithDataTypes(tableName string, columns model.TableSchema, notNullableColumns []string) string {
+	columnsWithDataTypes := lo.Map(lo.Keys(columns), func(columnName string, _ int) string {
+		dataType := columns[columnName]
+		codec := ch.getClickHouseCodecForColumnType(dataType, tableName)
+		columnType := ch.getClickHouseColumnTypeForSpecificTable(tableName, columnName, rudderDataTypesMapToClickHouse[dataType], slices.Contains(notNullableColumns, columnName))
+		return fmt.Sprintf(`%q %s %s`, columnName, columnType, codec)
+	})
+	return strings.Join(columnsWithDataTypes, ",")
+}
+
+func (ch *ClickhouseV2) getClickHouseCodecForColumnType(columnType, tableName string) string {
+	if columnType == model.DateTimeDataType {
+		if ch.config.disableNullable && (tableName != warehouseutils.IdentifiesTable && tableName != warehouseutils.UsersTable) {
+			return "Codec(DoubleDelta, LZ4)"
+		}
+	}
+	return ""
+}
+
+func (ch *ClickhouseV2) getClickHouseColumnTypeForSpecificTable(tableName, columnName, columnType string, notNullableKey bool) string {
+	if notNullableKey || (tableName != warehouseutils.IdentifiesTable && ch.config.disableNullable) {
+		return getClickhouseColumnTypeForSpecificColumn(columnName, columnType, false)
+	}
+	// Nullable is not disabled for users and identity table
+	if tableName == warehouseutils.UsersTable {
+		return fmt.Sprintf(`SimpleAggregateFunction(anyLast, %s)`, getClickhouseColumnTypeForSpecificColumn(columnName, columnType, true))
+	}
+	return getClickhouseColumnTypeForSpecificColumn(columnName, columnType, true)
+}
+
+func (ch *ClickhouseV2) partitionByClause() (string, error) {
+	partitionExpr, err := ch.partitionExpr()
+	if err != nil {
+		return "", fmt.Errorf("getting partition expr: %w", err)
+	}
+	return fmt.Sprintf(`PARTITION BY %s`, partitionExpr), nil
+}
+
+func (ch *ClickhouseV2) partitionExpr() (string, error) {
+	partitionType := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.PartitionTypeSetting)
+	switch partitionType {
+	case "", "day":
+		return fmt.Sprintf(`toDate(%s)`, partitionField), nil
+	case "week":
+		return fmt.Sprintf(`toStartOfWeek(%s)`, partitionField), nil
+	case "month":
+		return fmt.Sprintf(`toStartOfMonth(%s)`, partitionField), nil
+	case "quarter":
+		return fmt.Sprintf(`toStartOfQuarter(%s)`, partitionField), nil
+	default:
+		ch.logger.Warnn("CH: Invalid partition type for clickhouse destination",
+			logger.NewStringField("partitionType", partitionType),
+			logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
+		)
+		return "", fmt.Errorf("%w: %s", errInvalidPartitionType, partitionType)
+	}
+}
+
+func (ch *ClickhouseV2) DropTable(ctx context.Context, tableName string) (err error) {
+	sqlStatement := fmt.Sprintf(`DROP TABLE %q.%q %s `, ch.Warehouse.Namespace, tableName, ch.clusterClause())
+	_, err = ch.DB.ExecContext(ctx, sqlStatement)
+	return err
+}
+
+func (ch *ClickhouseV2) AddColumns(ctx context.Context, tableName string, columnsInfo []warehouseutils.ColumnInfo) (err error) {
+	var (
+		query        string
+		queryBuilder strings.Builder
+	)
+
+	queryBuilder.WriteString(fmt.Sprintf(`
+		ALTER TABLE
+		  %q.%q %s`,
+		ch.Namespace,
+		tableName,
+		ch.clusterClause(),
+	))
+
+	for _, columnInfo := range columnsInfo {
+		columnType := ch.getClickHouseColumnTypeForSpecificTable(
+			tableName,
+			columnInfo.Name,
+			rudderDataTypesMapToClickHouse[columnInfo.Type],
+			false,
+		)
+		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %q %s,`, columnInfo.Name, columnType))
+	}
+
+	query = strings.TrimSuffix(queryBuilder.String(), ",")
+	query += ";"
+
+	ch.logger.Infon("CH: Adding columns for destinationID with query",
+		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
+		logger.NewStringField(logfield.TableName, tableName),
+		logger.NewStringField(logfield.Query, query),
+	)
+	_, err = ch.DB.ExecContext(ctx, query)
+	return err
+}
+
+func (*ClickhouseV2) AlterColumn(_ context.Context, _, _, _ string) (model.AlterTableResponse, error) {
+	return model.AlterTableResponse{}, nil
+}
+
+// FetchSchema queries clickhouse and returns the schema associated with provided namespace
+func (ch *ClickhouseV2) FetchSchema(ctx context.Context) (model.Schema, error) {
+	schema := make(model.Schema)
+
+	sqlStatement := `
+		SELECT
+		  table,
+		  name,
+		  type
+		FROM
+		  system.columns
+		WHERE
+		  database = ?
+	`
+
+	rows, err := ch.DB.QueryContext(ctx, sqlStatement, ch.Namespace)
+	if errors.Is(err, sql.ErrNoRows) {
+		return schema, nil
+	}
+	if err != nil {
+		if isUnknownDatabase(err) {
+			return schema, nil
+		}
+		return nil, fmt.Errorf("fetching schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var tableName, columnName, columnType string
+
+		if err := rows.Scan(&tableName, &columnName, &columnType); err != nil {
+			return nil, fmt.Errorf("scanning schema row: %w", err)
+		}
+
+		if _, ok := schema[tableName]; !ok {
+			schema[tableName] = make(model.TableSchema)
+		}
+		if datatype, ok := clickhouseDataTypesMapToRudder[columnType]; ok {
+			schema[tableName][columnName] = datatype
+		} else {
+			warehouseutils.WHCounterStat(ch.stats, warehouseutils.RudderMissingDatatype, &ch.Warehouse, warehouseutils.Tag{Name: "datatype", Value: columnType}).Count(1)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating schema rows: %w", err)
+	}
+
+	return schema, nil
+}
+
+func (ch *ClickhouseV2) TestFetchSchema(ctx context.Context) error {
+	_, err := ch.FetchSchema(ctx)
+	return err
 }
 
 func (*ClickhouseV2) DeleteBy(context.Context, []string, warehouseutils.DeleteByParams) error {

--- a/warehouse/integrations/clickhouse/driver_v2.go
+++ b/warehouse/integrations/clickhouse/driver_v2.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -13,6 +14,9 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
+
+// unknownDatabase is ClickHouse's UNKNOWN_DATABASE error code.
+const unknownDatabase = 81
 
 // connect opens a connection and wraps it in the shared middleware.
 // includeDatabase is false when connecting in order to create the database.
@@ -83,4 +87,14 @@ func (ch *ClickhouseV2) tlsConfig() (*tls.Config, error) {
 	}
 	conf.RootCAs = caCertPool
 	return conf, nil
+}
+
+// isUnknownDatabase reports whether err is ClickHouse's UNKNOWN_DATABASE, which
+// FetchSchema treats as an empty schema rather than a failure.
+func isUnknownDatabase(err error) bool {
+	var chErr *clickhouse.Exception
+	if errors.As(err, &chErr) {
+		return chErr.Code == unknownDatabase
+	}
+	return false
 }


### PR DESCRIPTION
# Description

Table and column management for the v2 ClickHouse implementation, on top of the connection PR.

- `CreateTable` and the users table, including the ReplacingMergeTree / cluster handling
- column types and codecs, `notNullable` columns
- partitioning: day, week, month and quarter
- `DropTable`, `AddColumns`, `AlterColumn`
- `FetchSchema`, mapping ClickHouse's `UNKNOWN_DATABASE` to an empty schema rather than a failure, and `TestFetchSchema`

Independent of the loading PR — they touch disjoint files, so either can merge first.

Part of the #7299 split; still nothing constructs the v2 implementation, so this changes no behaviour.

## Linear Ticket

- Resolves INT-7019, INT-7018

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
