### PR TITLE
feat(warehouse): clickhouse v2 loading

### DIFF
--- a/warehouse/integrations/clickhouse/binder_v2.go
+++ b/warehouse/integrations/clickhouse/binder_v2.go
@@ -1,0 +1,115 @@
+package clickhouse
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+// bindValue converts one raw CSV cell into the exact Go type the column needs.
+//
+// Exact types matter: the driver accepts loosely-typed values and then
+// silently corrupts them — int(300) into a UInt8 column stores 44, float64(1.9)
+// into Int64 stores 1 — all without an error.
+//
+// On a cell that fails to parse the value resolves to nil for a nullable
+// column, or to the type's typed default when nullable columns are disabled.
+func (ch *ClickhouseV2) bindValue(data, dataType string) any {
+	var (
+		value any
+		err   error
+	)
+
+	switch dataType {
+	case model.IntDataType:
+		value, err = strconv.ParseInt(data, 10, 64)
+	case model.FloatDataType:
+		value, err = strconv.ParseFloat(data, 64)
+	case model.DateTimeDataType:
+		value, err = time.Parse(time.RFC3339, data)
+	case model.BooleanDataType:
+		var b bool
+		if b, err = strconv.ParseBool(data); b {
+			value = uint8(1)
+		} else {
+			value = uint8(0)
+		}
+	default:
+		if strings.Contains(dataType, "array") {
+			return ch.castStringToArray(data, dataType)
+		}
+		return data
+	}
+
+	if err != nil {
+		if ch.config.disableNullable {
+			return datatypeDefaultValuesMap[dataType]
+		}
+		return nil
+	}
+	return value
+}
+
+// castStringToArray unmarshals a JSON array cell into the typed slice the
+// column expects. Never returns a nil slice: the driver rejects nil for array
+// columns.
+func (ch *ClickhouseV2) castStringToArray(data, dataType string) any {
+	switch dataType {
+	case "array(int)":
+		dataInt := make([]int64, 0)
+		if err := jsonrs.Unmarshal([]byte(data), &dataInt); err != nil {
+			ch.logger.Errorn("Error while unmarshalling data into array of int", obskit.Error(err))
+		}
+		return dataInt
+	case "array(float)":
+		dataFloat := make([]float64, 0)
+		if err := jsonrs.Unmarshal([]byte(data), &dataFloat); err != nil {
+			ch.logger.Errorn("Error while unmarshalling data into array of float", obskit.Error(err))
+		}
+		return dataFloat
+	case "array(string)":
+		dataInterface := make([]any, 0)
+		if err := jsonrs.Unmarshal([]byte(data), &dataInterface); err != nil {
+			ch.logger.Errorn("Error while unmarshalling data into array of interface", obskit.Error(err))
+		}
+		dataString := make([]string, 0, len(dataInterface))
+		for _, value := range dataInterface {
+			if strValue, ok := value.(string); ok {
+				dataString = append(dataString, strValue)
+				continue
+			}
+			marshalled, _ := jsonrs.Marshal(value)
+			dataString = append(dataString, string(marshalled))
+		}
+		return dataString
+	case "array(datetime)":
+		dataTime := make([]time.Time, 0)
+		if err := jsonrs.Unmarshal([]byte(data), &dataTime); err != nil {
+			ch.logger.Errorn("Error while unmarshalling data into array of date time", obskit.Error(err))
+		}
+		return dataTime
+	case "array(boolean)":
+		// Booleans are written as 1/0 by the warehouse slave, so unmarshal into
+		// []int32 first and fall back to []bool.
+		dataInt := make([]int32, 0)
+		dataBool := make([]bool, 0)
+
+		if err := jsonrs.Unmarshal([]byte(data), &dataInt); err == nil {
+			for _, value := range dataInt {
+				dataBool = append(dataBool, value != 0)
+			}
+			return dataBool
+		}
+		if err := jsonrs.Unmarshal([]byte(data), &dataBool); err != nil {
+			ch.logger.Errorn("Error while unmarshalling data into array of bool", obskit.Error(err))
+			return dataBool
+		}
+		return dataBool
+	}
+	return data
+}

--- a/warehouse/integrations/clickhouse/driver_v2.go
+++ b/warehouse/integrations/clickhouse/driver_v2.go
@@ -18,6 +18,16 @@ import (
 // unknownDatabase is ClickHouse's UNKNOWN_DATABASE error code.
 const unknownDatabase = 81
 
+// s3CredentialsRegex masks the access key and secret that loadByCopyCommand
+// passes to the s3 table function. Without it the middleware logs the statement
+// verbatim once it crosses the slow query threshold, which a full table copy
+// does routinely. The credentials are positional single-quoted arguments rather
+// than named ones, so the pattern anchors on s3( and the location that precedes
+// them.
+var s3CredentialsRegex = map[string]string{
+	`(s3\(\s*'[^']*',\s*)'[^']*',\s*'[^']*'`: `${1}'***', '***'`,
+}
+
 // connect opens a connection and wraps it in the shared middleware.
 // includeDatabase is false when connecting in order to create the database.
 func (ch *ClickhouseV2) connect(includeDatabase bool) (*sqlmw.DB, error) {
@@ -67,6 +77,7 @@ func (ch *ClickhouseV2) connect(includeDatabase bool) (*sqlmw.DB, error) {
 		),
 		sqlmw.WithQueryTimeout(ch.connectTimeout),
 		sqlmw.WithSlowQueryThreshold(ch.config.slowQueryThreshold),
+		sqlmw.WithSecretsRegex(s3CredentialsRegex),
 	), nil
 }
 

--- a/warehouse/integrations/clickhouse/driver_v2_test.go
+++ b/warehouse/integrations/clickhouse/driver_v2_test.go
@@ -1,0 +1,77 @@
+package clickhouse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+// TestS3CredentialsRegexV2 guards the masking the middleware applies before it
+// logs a query. The statement below mirrors the one loadByCopyCommand builds:
+// if that template changes shape, this is what catches the credentials going
+// back into the logs.
+func TestS3CredentialsRegexV2(t *testing.T) {
+	const (
+		accessKeyID     = "AKIAIOSFODNN7EXAMPLE"
+		secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		loadFolder      = "s3://bucket/rudder/uploads/*.csv.gz"
+		columnTypes     = "id String,received_at DateTime"
+	)
+
+	statement := fmt.Sprintf(`
+		INSERT INTO %[1]q.%[2]q (
+			%[3]s
+		)
+		SELECT
+		  *
+		FROM
+		  s3(
+			'%[4]s',
+		  	'%[5]s',
+		  	'%[6]s',
+			'CSV',
+			'%[7]s',
+			'gz'
+		  )
+			settings
+				date_time_input_format = 'best_effort',
+				input_format_csv_arrays_as_nested_csv = 1;
+		`,
+		"namespace",      // 1
+		"table",          // 2
+		"id,received_at", // 3
+		loadFolder,       // 4
+		accessKeyID,      // 5
+		secretAccessKey,  // 6
+		columnTypes,      // 7
+	)
+
+	masked, err := misc.ReplaceMultiRegex(statement, s3CredentialsRegex)
+	require.NoError(t, err)
+
+	require.NotContains(t, masked, accessKeyID)
+	require.NotContains(t, masked, secretAccessKey)
+	require.Contains(t, masked, "'***', '***'")
+
+	// The rest of the statement has to survive, or the log stops being useful.
+	require.Contains(t, masked, loadFolder)
+	require.Contains(t, masked, columnTypes)
+	require.Contains(t, masked, "'CSV'")
+	require.Contains(t, masked, "date_time_input_format = 'best_effort'")
+
+	t.Run("masking twice changes nothing", func(t *testing.T) {
+		twice, err := misc.ReplaceMultiRegex(masked, s3CredentialsRegex)
+		require.NoError(t, err)
+		require.Equal(t, masked, twice)
+	})
+
+	t.Run("statements without s3 are untouched", func(t *testing.T) {
+		insert := `INSERT INTO "namespace"."table" ("id","received_at") VALUES (?,?)`
+		out, err := misc.ReplaceMultiRegex(insert, s3CredentialsRegex)
+		require.NoError(t, err)
+		require.Equal(t, insert, out)
+	})
+}

--- a/warehouse/integrations/clickhouse/load_v2.go
+++ b/warehouse/integrations/clickhouse/load_v2.go
@@ -365,11 +365,15 @@ func (ch *ClickhouseV2) insertBlock(
 ) (int, error) {
 	var inserted int
 
-	err := ch.DB.WithTx(ctx, func(txn *sqlmw.Tx) error {
+	err := ch.DB.WithTx(ctx, func(txCtx context.Context, txn *sqlmw.Tx) error {
 		// A *sql.Stmt belongs to its transaction, and sending a batch is what
 		// ends one, so every block prepares the same SQL again on a fresh
 		// transaction.
-		stmt, err := txn.PrepareContext(ctx, insertSQL)
+		//
+		// txCtx rather than ctx: the driver captures this context on the batch,
+		// and it is the only one batch.Send can observe. Whatever deadline it
+		// carries is what bounds the write.
+		stmt, err := txn.PrepareContext(txCtx, insertSQL)
 		if err != nil {
 			return fmt.Errorf("preparing statement %s: %w", insertSQL, err)
 		}
@@ -393,7 +397,7 @@ func (ch *ClickhouseV2) insertBlock(
 			for index, value := range record {
 				values = append(values, ch.bindValue(value, schema[columnKeys[index]]))
 			}
-			if _, err := stmt.ExecContext(ctx, values...); err != nil {
+			if _, err := stmt.ExecContext(txCtx, values...); err != nil {
 				return fmt.Errorf("executing statement: %w", err)
 			}
 			inserted++

--- a/warehouse/integrations/clickhouse/load_v2.go
+++ b/warehouse/integrations/clickhouse/load_v2.go
@@ -1,0 +1,404 @@
+package clickhouse
+
+import (
+	"compress/gzip"
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+var (
+	errObjectStorageNotSupported = errors.New("objectStorage not supported for loading using S3 engine")
+	errCSVColumnsMismatch        = errors.New("csv columns mismatch")
+)
+
+func (ch *ClickhouseV2) LoadTable(ctx context.Context, tableName string) (*types.LoadTableStats, error) {
+	var (
+		preLoadTableCount int64
+		err               error
+	)
+	if !ch.config.disableLoadTableStats(ch.Warehouse.WorkspaceID) {
+		preLoadTableCount, err = ch.totalCountIntable(ctx, tableName)
+		if err != nil {
+			return nil, fmt.Errorf("counting rows before load: %w", err)
+		}
+	}
+
+	err = ch.loadTable(ctx, tableName, ch.Uploader.GetTableSchemaInUpload(tableName))
+	if err != nil {
+		return nil, fmt.Errorf("loading table: %w", err)
+	}
+
+	var postLoadTableCount int64
+	if !ch.config.disableLoadTableStats(ch.Warehouse.WorkspaceID) {
+		postLoadTableCount, err = ch.totalCountIntable(ctx, tableName)
+		if err != nil {
+			return nil, fmt.Errorf("counting rows after load: %w", err)
+		}
+	}
+
+	return &types.LoadTableStats{
+		RowsInserted: postLoadTableCount - preLoadTableCount,
+	}, nil
+}
+
+func (ch *ClickhouseV2) totalCountIntable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM "%[1]s"."%[2]s";
+	`,
+		ch.Namespace,
+		tableName,
+	)
+	err = ch.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
+	return total, err
+}
+
+func (ch *ClickhouseV2) LoadUserTables(ctx context.Context) (errorMap map[string]error) {
+	errorMap = map[string]error{warehouseutils.IdentifiesTable: nil}
+	err := ch.loadTable(ctx, warehouseutils.IdentifiesTable, ch.Uploader.GetTableSchemaInUpload(warehouseutils.IdentifiesTable))
+	if err != nil {
+		errorMap[warehouseutils.IdentifiesTable] = err
+		return errorMap
+	}
+
+	if len(ch.Uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
+		return errorMap
+	}
+	errorMap[warehouseutils.UsersTable] = nil
+	err = ch.loadTable(ctx, warehouseutils.UsersTable, ch.Uploader.GetTableSchemaInUpload(warehouseutils.UsersTable))
+	if err != nil {
+		errorMap[warehouseutils.UsersTable] = err
+		return errorMap
+	}
+	return errorMap
+}
+
+func (ch *ClickhouseV2) loadTable(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) (err error) {
+	if delay := ch.config.randomLoadDelay(ch.Warehouse.WorkspaceID); delay > 0 {
+		if err = misc.SleepCtx(ctx, delay); err != nil {
+			return err
+		}
+	}
+	if ch.UseS3CopyEngineForLoading() {
+		return ch.loadByCopyCommand(ctx, tableName, tableSchemaInUpload)
+	}
+	return ch.loadByDownloadingLoadFiles(ctx, tableName, tableSchemaInUpload)
+}
+
+func (ch *ClickhouseV2) UseS3CopyEngineForLoading() bool {
+	if !slices.Contains(ch.config.s3EngineEnabledWorkspaceIDs, ch.Warehouse.WorkspaceID) {
+		return false
+	}
+	return ch.ObjectStorage == warehouseutils.S3 || ch.ObjectStorage == warehouseutils.MINIO
+}
+
+func (ch *ClickhouseV2) loadByCopyCommand(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) error {
+	log := ch.logger.Withn(
+		logger.NewStringField(logfield.SourceID, ch.Warehouse.Source.ID),
+		logger.NewStringField(logfield.SourceType, ch.Warehouse.Source.SourceDefinition.Name),
+		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
+		logger.NewStringField(logfield.DestinationType, ch.Warehouse.Destination.DestinationDefinition.Name),
+		logger.NewStringField(logfield.WorkspaceID, ch.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.Namespace, ch.Namespace),
+		logger.NewStringField(logfield.TableName, tableName),
+	)
+	log.Infon("Starting load by copy command")
+
+	strKeys := warehouseutils.GetColumnsFromTableSchema(tableSchemaInUpload)
+	sort.Strings(strKeys)
+	sortedColumnNames := strings.Join(strKeys, ",")
+	sortedColumnNamesWithDataTypes := warehouseutils.JoinWithFormatting(strKeys, func(idx int, name string) string {
+		return fmt.Sprintf(`%s %s`, name, rudderDataTypesMapToClickHouse[tableSchemaInUpload[name]])
+	}, ",")
+
+	csvObjectLocation, err := ch.Uploader.GetSampleLoadFileLocation(ctx, tableName)
+	if err != nil {
+		return fmt.Errorf("getting sample load file location: %w", err)
+	}
+	loadFolderDir, _ := path.Split(csvObjectLocation)
+	loadFolder := loadFolderDir + "*.csv.gz"
+
+	accessKeyID, secretAccessKey, err := ch.credentials()
+	if err != nil {
+		return fmt.Errorf("getting auth credentials: %w", err)
+	}
+
+	sqlStatement := fmt.Sprintf(`
+		INSERT INTO %[1]q.%[2]q (
+			%[3]s
+		)
+		SELECT
+		  *
+		FROM
+		  s3(
+			'%[4]s',
+		  	'%[5]s',
+		  	'%[6]s',
+			'CSV',
+			'%[7]s',
+			'gz'
+		  )
+			settings
+				date_time_input_format = 'best_effort',
+				input_format_csv_arrays_as_nested_csv = 1;
+		`,
+		ch.Namespace,                   // 1
+		tableName,                      // 2
+		sortedColumnNames,              // 3
+		loadFolder,                     // 4
+		accessKeyID,                    // 5
+		secretAccessKey,                // 6
+		sortedColumnNamesWithDataTypes, // 7
+	)
+	_, err = ch.DB.ExecContext(ctx, sqlStatement)
+	if err != nil {
+		return fmt.Errorf("executing insert query: %w", err)
+	}
+
+	log.Infon("Completed load by copy command")
+	return nil
+}
+
+func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) error {
+	log := ch.logger.Withn(
+		logger.NewStringField(logfield.SourceID, ch.Warehouse.Source.ID),
+		logger.NewStringField(logfield.SourceType, ch.Warehouse.Source.SourceDefinition.Name),
+		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
+		logger.NewStringField(logfield.DestinationType, ch.Warehouse.Destination.DestinationDefinition.Name),
+		logger.NewStringField(logfield.WorkspaceID, ch.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.Namespace, ch.Namespace),
+		logger.NewStringField(logfield.TableName, tableName),
+	)
+	log.Infon("Starting load by downloading load files")
+
+	fileNames, err := ch.LoadFileDownloader.Download(ctx, tableName)
+	if err != nil {
+		return fmt.Errorf("downloading load files: %w", err)
+	}
+	defer func() {
+		misc.RemoveFilePaths(fileNames...)
+	}()
+
+	if err := ch.loadTableFromFiles(ctx, log, tableName, tableSchemaInUpload, fileNames); err != nil {
+		return fmt.Errorf("loading table from files: %w", err)
+	}
+	log.Infon("Completed load by downloading load files")
+	return nil
+}
+
+func (ch *ClickhouseV2) credentials() (accessKeyID, secretAccessKey string, err error) {
+	if ch.ObjectStorage == warehouseutils.S3 {
+		return ch.Warehouse.GetStringDestinationConfig(ch.conf, model.AWSAccessSecretSetting), ch.Warehouse.GetStringDestinationConfig(ch.conf, model.AWSAccessKeySetting), nil
+	}
+	if ch.ObjectStorage == warehouseutils.MINIO {
+		return ch.Warehouse.GetStringDestinationConfig(ch.conf, model.MinioAccessKeyIDSetting), ch.Warehouse.GetStringDestinationConfig(ch.conf, model.MinioSecretAccessKeySetting), nil
+	}
+	return "", "", errObjectStorageNotSupported
+}
+
+func (ch *ClickhouseV2) TestLoadTable(ctx context.Context, _, tableName string, payloadMap map[string]any, _ string) error {
+	// One pass over the map. Collecting keys and values separately means two
+	// iterations, and Go randomises map order, so a value can end up paired with
+	// the wrong column.
+	columns := make([]string, 0, len(payloadMap))
+	values := make([]any, 0, len(payloadMap))
+	for column, value := range payloadMap {
+		columns = append(columns, column)
+		values = append(values, value)
+	}
+
+	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
+		ch.Namespace,
+		tableName,
+		strings.Join(columns, ","),
+		generateArgumentString(len(columns)),
+	)
+	txn, err := ch.DB.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = txn.Rollback()
+		}
+	}()
+
+	stmt, err := txn.PrepareContext(ctx, sqlStatement)
+	if err != nil {
+		return fmt.Errorf("preparing statement: %w", err)
+	}
+	defer func() {
+		_ = stmt.Close()
+	}()
+
+	if _, err = stmt.ExecContext(ctx, values...); err != nil {
+		return fmt.Errorf("executing statement: %w", err)
+	}
+	if err = txn.Commit(); err != nil {
+		return fmt.Errorf("committing transaction: %w", err)
+	}
+	return nil
+}
+
+// loadTableFromFiles inserts every row of every load file into tableName, in
+// blocks of commitEvery rows.
+//
+// The load files are read as one stream rather than one at a time: they are
+// headerless CSV in separate gzip members, so concatenating them and running a
+// single gzip reader over the lot yields one row sequence for the table. Blocks
+// therefore span load files instead of ending early at each one, which is what
+// keeps the number of inserts — and so the number of parts ClickHouse has to
+// merge — proportional to the rows loaded rather than to the file count.
+//
+// ExecContext only appends to a client-side batch and the single wire write
+// happens on commit, so commitEvery is what bounds how much of the upload is
+// held in memory at once.
+func (ch *ClickhouseV2) loadTableFromFiles(
+	ctx context.Context,
+	log logger.Logger,
+	tableName string,
+	tableSchemaInUpload model.TableSchema,
+	fileNames []string,
+) error {
+	if len(fileNames) == 0 {
+		return nil
+	}
+
+	sortedColumnKeys := warehouseutils.SortColumnKeysFromColumnMap(tableSchemaInUpload)
+	insertSQL := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
+		ch.Namespace,
+		tableName,
+		warehouseutils.DoubleQuoteAndJoinByComma(sortedColumnKeys),
+		generateArgumentString(len(sortedColumnKeys)),
+	)
+
+	files := make([]*os.File, 0, len(fileNames))
+	defer func() {
+		for _, file := range files {
+			_ = file.Close()
+		}
+	}()
+
+	readers := make([]io.Reader, 0, len(fileNames))
+	for _, fileName := range fileNames {
+		file, err := os.Open(fileName)
+		if err != nil {
+			return fmt.Errorf("opening load file %s: %w", fileName, err)
+		}
+		files = append(files, file)
+		readers = append(readers, file)
+	}
+
+	gzipReader, err := gzip.NewReader(io.MultiReader(readers...))
+	if err != nil {
+		return fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer func() { _ = gzipReader.Close() }()
+
+	var rows int
+	csvReader := csv.NewReader(gzipReader)
+	for {
+		inserted, err := ch.insertBlock(ctx, insertSQL, csvReader, sortedColumnKeys, tableSchemaInUpload)
+		if err != nil {
+			return fmt.Errorf("inserting block after %d rows: %w", rows, err)
+		}
+
+		rows += inserted
+		// A short block means insertBlock hit EOF, so the stream is done. Only a
+		// row count that is an exact multiple of commitEvery costs one more call.
+		if inserted < ch.config.commitEvery {
+			break
+		}
+	}
+
+	log.Debugn("Load files processed",
+		logger.NewIntField("files", int64(len(fileNames))),
+		logger.NewIntField("rows", int64(rows)),
+	)
+	return nil
+}
+
+// insertBlock reads up to commitEvery rows from csvReader and sends them as one
+// batch — one transaction per block, not per row. It reports how many rows it
+// sent, and zero means the stream is exhausted.
+//
+// A return below commitEvery means EOF was reached, which is how the caller
+// knows to stop. When the row count is an exact multiple of commitEvery the
+// caller makes one more call that reads EOF and commits nothing: that costs a
+// prepare and a query close but no data frame, since batch.Send skips the send
+// entirely for a zero-row block.
+//
+// "Transaction" is the driver's word, not ClickHouse's: BeginTx sends nothing
+// and only health-checks the connection, Commit is batch.Send, and Rollback
+// discards an unsent batch and closes the connection. Preparing a batch and
+// sending it is the only thing the transaction is for. A block is therefore
+// atomic only until it is sent, and a failure part-way through a load leaves
+// the blocks before it already in the table.
+func (ch *ClickhouseV2) insertBlock(
+	ctx context.Context,
+	insertSQL string,
+	csvReader *csv.Reader,
+	columnKeys []string,
+	schema model.TableSchema,
+) (int, error) {
+	var inserted int
+
+	err := ch.DB.WithTx(ctx, func(txn *sqlmw.Tx) error {
+		// A *sql.Stmt belongs to its transaction, and sending a batch is what
+		// ends one, so every block prepares the same SQL again on a fresh
+		// transaction.
+		stmt, err := txn.PrepareContext(ctx, insertSQL)
+		if err != nil {
+			return fmt.Errorf("preparing statement %s: %w", insertSQL, err)
+		}
+		defer func() { _ = stmt.Close() }()
+
+		for inserted < ch.config.commitEvery {
+			record, err := csvReader.Read()
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("reading csv: %w", err)
+			}
+			if len(columnKeys) != len(record) {
+				return fmt.Errorf("%w: columns in row: %d, columns in upload schema: %d",
+					errCSVColumnsMismatch, len(record), len(columnKeys),
+				)
+			}
+
+			values := make([]any, 0, len(record))
+			for index, value := range record {
+				values = append(values, ch.bindValue(value, schema[columnKeys[index]]))
+			}
+			if _, err := stmt.ExecContext(ctx, values...); err != nil {
+				return fmt.Errorf("executing statement: %w", err)
+			}
+			inserted++
+		}
+		return nil
+	})
+	return inserted, err
+}

--- a/warehouse/integrations/middleware/sqlquerywrapper/sql.go
+++ b/warehouse/integrations/middleware/sqlquerywrapper/sql.go
@@ -201,7 +201,10 @@ func (db *DB) QueryRowContext(ctx context.Context, query string, args ...any) *R
 	}
 }
 
-func (db *DB) WithTx(ctx context.Context, fn func(*Tx) error) error {
+// WithTx runs fn inside a transaction. The context passed to fn is the one
+// the transaction was opened with, so it carries the query timeout; work
+// inside fn that uses the caller's context instead is not covered by it.
+func (db *DB) WithTx(ctx context.Context, fn func(context.Context, *Tx) error) error {
 	ctx, cancel := queryContextWithTimeout(ctx, db.queryTimeout)
 	defer cancel()
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
@@ -209,7 +212,7 @@ func (db *DB) WithTx(ctx context.Context, fn func(*Tx) error) error {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 
-	if err = fn(tx); err != nil {
+	if err = fn(ctx, tx); err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
 			keysAndValues := []any{logfield.Error, fmt.Errorf("executing transaction: %s, rollback: %s", err.Error(), rollbackErr.Error()).Error()}
 			keysAndValues = append(keysAndValues, db.keysAndValues...)

--- a/warehouse/integrations/postgres/load.go
+++ b/warehouse/integrations/postgres/load.go
@@ -47,10 +47,10 @@ func (pg *Postgres) LoadTable(ctx context.Context, tableName string) (*types.Loa
 	cancel := safeguard.MustStop(ctx, 5*time.Minute)
 	defer cancel()
 
-	err := pg.DB.WithTx(ctx, func(tx *sqlmiddleware.Tx) error {
+	err := pg.DB.WithTx(ctx, func(txCtx context.Context, tx *sqlmiddleware.Tx) error {
 		var err error
 		loadTableStats, _, err = pg.loadTable(
-			ctx,
+			txCtx,
 			tx,
 			tableName,
 			pg.Uploader.GetTableSchemaInUpload(tableName),
@@ -336,8 +336,8 @@ func (pg *Postgres) LoadUserTables(ctx context.Context) map[string]error {
 	usersSchemaInWarehouse := pg.Uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
 
 	var loadingError loadUsersTableResponse
-	_ = pg.DB.WithTx(ctx, func(tx *sqlmiddleware.Tx) error {
-		loadingError = pg.loadUsersTable(ctx, tx, identifiesSchemaInUpload, usersSchemaInUpload, usersSchemaInWarehouse)
+	_ = pg.DB.WithTx(ctx, func(txCtx context.Context, tx *sqlmiddleware.Tx) error {
+		loadingError = pg.loadUsersTable(txCtx, tx, identifiesSchemaInUpload, usersSchemaInUpload, usersSchemaInWarehouse)
 		if loadingError.identifiesError != nil || loadingError.usersError != nil {
 			return errors.New("loading users and identifies table")
 		}

--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -160,7 +160,7 @@ func (u *Uploads) CreateWithStagingFiles(ctx context.Context, upload model.Uploa
 
 	var uploadID int64
 
-	err = u.db.WithTx(ctx, func(tx *sqlmiddleware.Tx) error {
+	err = u.db.WithTx(ctx, func(txCtx context.Context, tx *sqlmiddleware.Tx) error {
 		err := tx.QueryRow(
 			`INSERT INTO `+uploadsTableName+` (
 			source_id, namespace, workspace_id, destination_id,


### PR DESCRIPTION
Adds the loading path for the ClickHouse v2 driver. `ClickhouseV2` and its connection scaffolding are already on master; this is the part that gets rows into a table.

## Loading

`load_v2.go` keeps v1's two paths: the S3 copy engine for allowlisted workspaces, otherwise download the load files and stream them in.

`loadTableFromFiles` reads every load file as one stream rather than one file at a time. They are headerless CSV in separate gzip members, so concatenating them and running a single gzip reader over the lot yields one row sequence for the table. Blocks therefore span load files instead of ending early at each one, which keeps the number of inserts — and so the number of parts ClickHouse has to merge — proportional to the rows loaded rather than to the file count.

`insertBlock` sends `Warehouse.clickhouse.v2.commitEvery` rows per batch. `stmt.ExecContext` only appends to a client-side block and the single wire write happens on commit, so `commitEvery` is what bounds how much of an upload is held in memory at once.

"Transaction" is the driver's word here, not ClickHouse's: `BeginTx` sends nothing and only health-checks the connection, `Commit` is `batch.Send`, and `Rollback` discards an unsent batch and closes the connection. A block is atomic only until it is sent, so a failure part-way through a load leaves the blocks before it already in the table.

## Value binding

`binder_v2.go` converts each CSV cell into the exact Go type the column needs. Exact types matter because the driver accepts loosely-typed values and then silently corrupts them — `int(300)` into a `UInt8` column stores 44, `float64(1.9)` into `Int64` stores 1, neither with an error. A cell that fails to parse resolves to `nil`, or to the type's typed default when nullable columns are disabled. `castStringToArray` never returns a nil slice, which the driver rejects for array columns.

## sqlquerywrapper: `WithTx` hands its context to the callback

`WithTx` derived a context carrying `queryTimeout` and then called `fn(tx)`, so every caller shadowed it with the outer context and the timeout was silently inert inside transactions. The callback now receives that context.

This is load-bearing for the ClickHouse insert. The only context `batch.Send` can observe is the one captured on the batch at `PrepareContext`, so passing the transaction's context there is what allows a deadline to reach the wire write at all — `prepareBatch` turns it into a socket deadline, and `contextWatchdog` closes the connection if it is cancelled mid-send. (`stmt.ExecContext`'s context is discarded by the driver; that call is an in-memory append.)

Postgres now uses the transaction's context in both `WithTx` bodies. `repo/upload.go`'s body doesn't reference a context, so it is unchanged in behaviour.

## s3 credentials no longer reach the query log

`loadByCopyCommand` passes the access key and secret to the `s3` table function as literals, and the v2 middleware was constructed without a secrets regex — so `logQuery` wrote both at Info once a copy crossed `slowQueryThreshold`, which a full-table copy does routinely. Now masked, as redshift, snowflake and deltalake already do.

Unlike theirs, `s3()` takes positional arguments, so there is no label to anchor on: the pattern keeps the load folder and masks the two values that follow it. Reordering the argument list would silently reopen this, so `driver_v2_test.go` covers it.

## Configuration

Everything is under `Warehouse.clickhouse.v2.*` (`commitEvery`, `poolSize`, `readTimeout`, `compress`, `disableNullable`, `numWorkersDownloadLoadFiles`, `s3EngineEnabledWorkspaceIDs`, `slowQueryThreshold`, `maxLoadDelay`, `disableLoadTableStats`, `queryDebugLogs`).

These do **not** fall back to the v1 keys, so any destination-level overrides in place today revert to defaults when the flag flips. `disableNullable` and `s3EngineEnabledWorkspaceIDs` change behaviour rather than just timing, so it is worth checking what is set before enabling this anywhere.

## Follow-ups, deliberately not here

- **No wall-clock bound on the batch write.** v1 had `write_timeout=1800` in the DSN plus `execTimeOutInSeconds` / `commitTimeOutInSeconds` enforced through `misc.RunWithTimeout`. clickhouse-go/v2 has no write-timeout option and `sendData` sets no deadline of its own, so the ack half of a commit is bounded by `ReadTimeout` (300s) but the write half is not: a node that stops draining its socket parks a loader indefinitely. This needs its own per-block timeout config — `connectTimeout` cannot stand in, since it is also `DialTimeout` and governs the long-running S3 copy.
- **No equivalent of `loadTableFailureRetries`.** A retry wrapped around `insertBlock` as it stands would skip rows, because the block is read from the shared `csv.Reader` inside the transaction; a correct one has to buffer the block first, and needs a duplicate story.
- v1 (`clickhouse.go`) has the same s3 credential logging gap. Left alone as out of scope for this PR.

## Testing

Unit coverage for the credential masking is in `driver_v2_test.go`. Integration coverage for the v2 driver lands in `feat.clickhouse-v2-tests`, which stacks on this branch.
