### PR TITLE
fix: replay destinations not using the config corresponding to their connected source type

### DIFF
--- a/backend-config/replay_types.go
+++ b/backend-config/replay_types.go
@@ -15,7 +15,7 @@ func (c *ConfigT) ApplyReplaySources() {
 		return
 	}
 	originalSources := c.SourcesMap()
-	originalDestinations := c.DestinationsMap()
+	originalDestinations := c.destinationsBySourceType()
 	for _, replay := range c.EventReplays {
 		sources := lo.OmitByValues(lo.MapValues(replay.Sources, func(value EventReplaySource, id string) *SourceT {
 			s, ok := originalSources[value.OriginalSourceID]
@@ -30,29 +30,29 @@ func (c *ConfigT) ApplyReplaySources() {
 			newSource.Destinations = nil                                  // destinations are added later
 			return &newSource
 		}), []*SourceT{nil})
-		destinations := lo.OmitByValues(lo.MapValues(replay.Destinations, func(value EventReplayDestination, id string) *DestinationT {
-			d, ok := originalDestinations[value.OriginalDestinationID]
-			if !ok {
-				return nil
-			}
-			newDestination := *d
-			newDestination.ID = id
-			newDestination.OriginalID = d.ID
-			newDestination.IsProcessorEnabled = true // processor is always enabled for replay destinations
-			return &newDestination
-		}), []*DestinationT{nil})
-
-		// add destinations to sources
+		// add destinations to sources. The instance to copy depends on the source it is being
+		// attached to, so it is resolved per connection rather than once per replay destination
 		for _, connection := range replay.Connections {
 			source, ok := sources[connection.SourceID]
 			if !ok {
 				continue
 			}
-			destination, ok := destinations[connection.DestinationID]
+			replayDestination, ok := replay.Destinations[connection.DestinationID]
 			if !ok {
 				continue
 			}
-			source.Destinations = append(source.Destinations, *destination)
+			original, ok := destinationForSourceType(
+				originalDestinations[replayDestination.OriginalDestinationID],
+				sourceTypeOf(source.SourceDefinition.Name, source.SourceDefinition.Category),
+			)
+			if !ok {
+				continue
+			}
+			newDestination := *original
+			newDestination.ID = connection.DestinationID
+			newDestination.OriginalID = original.ID
+			newDestination.IsProcessorEnabled = true // processor is always enabled for replay destinations
+			source.Destinations = append(source.Destinations, newDestination)
 		}
 
 		// add replay sources to config, only the ones that have destinations
@@ -79,4 +79,51 @@ type EventReplayDestination struct {
 type EventReplayConnection struct {
 	SourceID      string `json:"sourceId"`
 	DestinationID string `json:"destinationId"`
+}
+
+// destinationsBySourceType indexes every destination instance by its id and by the source type of
+// the source it is nested under.
+//
+// A destination connected to several sources appears once per source, and those copies are not
+// interchangeable: the control plane filters a destination's config against the keys its definition
+// declares for the source type it is connected to. Instances sharing a source type are identical,
+// which is why one per type is enough.
+func (c *ConfigT) destinationsBySourceType() map[string]map[string]*DestinationT {
+	byID := make(map[string]map[string]*DestinationT)
+	for i := range c.Sources {
+		source := c.Sources[i]
+		sourceType := sourceTypeOf(source.SourceDefinition.Name, source.SourceDefinition.Category)
+		for j := range source.Destinations {
+			destination := source.Destinations[j]
+			byType, ok := byID[destination.ID]
+			if !ok {
+				byType = make(map[string]*DestinationT)
+				byID[destination.ID] = byType
+			}
+			byType[sourceType] = &destination
+		}
+	}
+	return byID
+}
+
+// destinationForSourceType picks the instance a replay source of the given type should copy.
+//
+// A replay does not have to name a source and a destination that were ever connected, so the
+// instance for that exact source may not exist. In that case the first source type in ascending
+// order is taken: an arbitrary choice, but a fixed one, where reading the destination out of a map
+// keyed by id alone would return whichever instance the map happened to hold.
+func destinationForSourceType(byType map[string]*DestinationT, sourceType string) (*DestinationT, bool) {
+	if destination, ok := byType[sourceType]; ok {
+		return destination, true
+	}
+	var (
+		fallbackType string
+		fallback     *DestinationT
+	)
+	for candidate, destination := range byType {
+		if fallback == nil || candidate < fallbackType {
+			fallbackType, fallback = candidate, destination
+		}
+	}
+	return fallback, fallback != nil
 }

--- a/backend-config/replay_types_test.go
+++ b/backend-config/replay_types_test.go
@@ -2,6 +2,7 @@ package backendconfig
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -140,5 +141,85 @@ func TestApplyReplayConfig(t *testing.T) {
 		require.JSONEq(t, "{}", string(c.Sources[1].Config))
 		require.Len(t, c.Sources[1].Destinations, 1)
 		require.Equal(t, "er-d-1", c.Sources[1].Destinations[0].ID)
+	})
+}
+
+// A destination connected to several sources appears once per source, and the control plane gives
+// each copy a different config: it filters against the keys the destination's definition declares
+// for that source's type. A replay destination has to copy the instance belonging to its own
+// source's type, and has to keep copying the same one on every poll.
+func TestApplyReplaySourcesDestinationConfig(t *testing.T) {
+	// "Javascript" resolves to the web source type, an empty definition name to cloud
+	config := func(sourceTypes ...string) *ConfigT {
+		c := &ConfigT{
+			EventReplays: map[string]EventReplayConfig{
+				"er-1": {
+					Sources:      map[string]EventReplaySource{"er-s-1": {OriginalSourceID: "s-replayed"}},
+					Destinations: map[string]EventReplayDestination{"er-d-1": {OriginalDestinationID: "d-1"}},
+					Connections:  []EventReplayConnection{{SourceID: "er-s-1", DestinationID: "er-d-1"}},
+				},
+			},
+		}
+		for i, definitionName := range sourceTypes {
+			c.Sources = append(c.Sources, SourceT{
+				ID:               fmt.Sprintf("s-%d", i),
+				SourceDefinition: SourceDefinitionT{Name: definitionName},
+				Destinations: []DestinationT{{
+					ID:     "d-1",
+					Config: map[string]any{"filteredFor": sourceTypeOf(definitionName, "")},
+				}},
+			})
+		}
+		return c
+	}
+
+	replayed := func(t *testing.T, c *ConfigT) DestinationT {
+		t.Helper()
+		c.ApplyReplaySources()
+		source, ok := c.SourcesMap()["er-s-1"]
+		require.True(t, ok, "the replay source was not added")
+		require.Len(t, source.Destinations, 1)
+		return source.Destinations[0]
+	}
+
+	t.Run("copies the instance of its own source type", func(t *testing.T) {
+		c := config("Javascript", "")
+		c.Sources[0].ID = "s-replayed" // the replay is of the web source
+		destination := replayed(t, c)
+
+		require.Equal(t, "er-d-1", destination.ID)
+		require.Equal(t, "d-1", destination.OriginalID)
+		require.True(t, destination.IsProcessorEnabled)
+		require.Equal(t, "web", destination.Config["filteredFor"])
+	})
+
+	t.Run("and does so whichever source the destination is listed under first", func(t *testing.T) {
+		c := config("", "Javascript")
+		c.Sources[1].ID = "s-replayed"
+		require.Equal(t, "web", replayed(t, c).Config["filteredFor"])
+	})
+
+	t.Run("the replayed pair need never have been connected", func(t *testing.T) {
+		// s-replayed is a web source carrying no destinations at all; d-1 lives under two other
+		// sources, one of which is also web
+		c := config("Javascript", "")
+		c.Sources = append(c.Sources, SourceT{
+			ID:               "s-replayed",
+			SourceDefinition: SourceDefinitionT{Name: "Javascript"},
+		})
+		require.Equal(t, "web", replayed(t, c).Config["filteredFor"])
+	})
+
+	t.Run("falls back to the first source type in order, and keeps falling back to the same one", func(t *testing.T) {
+		for range 20 { // the failure this guards against is a map iteration order flake
+			// d-1 is on a web and a cloud source; the replayed source is neither
+			c := config("Javascript", "")
+			c.Sources = append(c.Sources, SourceT{
+				ID:               "s-replayed",
+				SourceDefinition: SourceDefinitionT{Name: "snowflake", Category: "warehouse"},
+			})
+			require.Equal(t, "cloud", replayed(t, c).Config["filteredFor"],
+				`"cloud" sorts before "web"`)
+		}
 	})
 }

--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -2,6 +2,7 @@ package backendconfig
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -54,6 +55,33 @@ type SourceDefinitionT struct {
 type SourceDefinitionOptions struct {
 	Hydration struct {
 		Enabled bool
+	}
+}
+
+// sourceTypeOf is the source type a destination's config is filtered for. A destination connected
+// to several sources carries a different config under each source type, so this is what tells two
+// instances of the same destination apart.
+//
+// A port of the control plane's ServiceUtil.getSourceType. Note the default: a source type it does
+// not know is "cloud", not the lowercased definition name.
+func sourceTypeOf(definitionName, category string) string {
+	switch category {
+	case "cloud", "singer":
+		return "cloudSource"
+	case "warehouse":
+		return "warehouse"
+	}
+	switch name := strings.ToLower(definitionName); name {
+	case "javascript":
+		return "web"
+	case "android_kotlin":
+		return "androidKotlin"
+	case "ios_swift":
+		return "iosSwift"
+	case "android", "ios", "unity", "reactnative", "amp", "flutter", "cordova", "shopify":
+		return name
+	default:
+		return "cloud"
 	}
 }
 


### PR DESCRIPTION
# Description

A destination connected to several sources appears once per source, and those copies are **not interchangeable**: the control plane filters a destination's config against the keys its definition declares for the connected source's type. `ApplyReplaySources` read it out of `ConfigT.DestinationsMap()`, keyed by id alone and last-write-wins, so a replay destination inherited an arbitrary copy - quite possibly one filtered for an unrelated source type. In the sampled namespace a Snowflake destination sits on 19 sources: the 18 cloud/webhook ones carry `connectionMode`, the single iOS one does not.

Found while writing the v2 mapper (PIPE-3279), whose fixture comparison against a captured v1 response failed ~1 run in 3 on unchanged input.

## Key decisions

- **Resolved by source type, not by the (source, destination) pair.** Filtering varies on source type alone, so instances sharing one are identical - and a replay does not require that its source and destination were ever connected.
- **The fallback is arbitrary but fixed** (first source type in ascending order).

## Linear Ticket

resolves PIPE-3320

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
