### PR TITLE
fix: tracking plan merged config is cached without its event type

### DIFF
--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -278,28 +278,15 @@ type DgSourceTrackingPlanConfigT struct {
 	SourceId            string                    `json:"sourceId"`
 	SourceConfigVersion int                       `json:"version"`
 	Config              map[string]map[string]any `json:"config"`
-	MergedConfig        map[string]any            `json:"mergedConfig"`
 	Deleted             bool                      `json:"deleted"`
 	TrackingPlan        TrackingPlanT             `json:"trackingPlan"`
 }
 
+// GetMergedConfig returns the tracking plan config that applies to an event type: the global
+// config with the event type's own config layered over it. Either may be absent, and the result is
+// always a non nil map.
 func (dgSourceTPConfigT *DgSourceTrackingPlanConfigT) GetMergedConfig(eventType string) map[string]any {
-	if dgSourceTPConfigT.MergedConfig == nil {
-		globalConfig := dgSourceTPConfigT.fetchEventConfig(GlobalEventType)
-		eventSpecificConfig := dgSourceTPConfigT.fetchEventConfig(eventType)
-		outputConfig := lo.Assign(globalConfig, eventSpecificConfig)
-		dgSourceTPConfigT.MergedConfig = outputConfig
-	}
-	return dgSourceTPConfigT.MergedConfig
-}
-
-func (dgSourceTPConfigT *DgSourceTrackingPlanConfigT) fetchEventConfig(eventType string) map[string]any {
-	emptyMap := map[string]any{}
-	_, eventSpecificConfigPresent := dgSourceTPConfigT.Config[eventType]
-	if !eventSpecificConfigPresent {
-		return emptyMap
-	}
-	return dgSourceTPConfigT.Config[eventType]
+	return lo.Assign(dgSourceTPConfigT.Config[GlobalEventType], dgSourceTPConfigT.Config[eventType])
 }
 
 type TrackingPlanT struct {

--- a/backend-config/types_test.go
+++ b/backend-config/types_test.go
@@ -127,3 +127,43 @@ func TestDestinationT_Version(t *testing.T) {
 		require.Equal(t, 2, cfg.Sources[0].Destinations[0].Version)
 	})
 }
+
+func TestGetMergedConfig(t *testing.T) {
+	plan := DgSourceTrackingPlanConfigT{
+		Config: map[string]map[string]any{
+			"global":   {"allowUnplannedEvents": true, "unplannedProperties": "drop"},
+			"track":    {"unplannedProperties": "forward", "propertiesRule": "track-rules"},
+			"identify": {"traitsRule": "identify-rules"},
+		},
+	}
+
+	t.Run("the event type's config is layered over the global one", func(t *testing.T) {
+		require.Equal(t, map[string]any{
+			"allowUnplannedEvents": true,
+			"unplannedProperties":  "forward", // the event type wins
+			"propertiesRule":       "track-rules",
+		}, plan.GetMergedConfig("track"))
+	})
+
+	t.Run("every event type gets its own, however many are asked for", func(t *testing.T) {
+		// the merge used to be memoised in a field with no room for the event type, so the first
+		// caller's answer was handed to every later one
+		require.Equal(t, "track-rules", plan.GetMergedConfig("track")["propertiesRule"])
+		require.Equal(t, "identify-rules", plan.GetMergedConfig("identify")["traitsRule"])
+		require.NotContains(t, plan.GetMergedConfig("identify"), "propertiesRule")
+		require.Equal(t, "drop", plan.GetMergedConfig("page")["unplannedProperties"],
+			"an event type with no config of its own gets the global one")
+	})
+
+	t.Run("mutating the result leaves the config alone", func(t *testing.T) {
+		merged := plan.GetMergedConfig("track")
+		merged["propertiesRule"] = "mutated"
+		require.Equal(t, "track-rules", plan.GetMergedConfig("track")["propertiesRule"])
+	})
+
+	t.Run("a plan with no config at all", func(t *testing.T) {
+		var empty DgSourceTrackingPlanConfigT
+		require.NotNil(t, empty.GetMergedConfig("track"))
+		require.Empty(t, empty.GetMergedConfig("track"))
+	})
+}


### PR DESCRIPTION
# Description

`DgSourceTrackingPlanConfigT.GetMergedConfig(eventType)` layers the tracking plan's config for an event type over its `global` config, and memoised the result into the source's own `DgSourceTrackingPlanConfig.MergedConfig`.

Caching it there is both **wrong** and **dangerous**. Wrong, because the field has no room for the event type it was merged for, so the first caller's answer is handed to every later one:

```
track    -> map[allowUnplannedEvents:true propertiesRule:track-rules]
identify -> map[allowUnplannedEvents:true propertiesRule:track-rules]   <- identify's rules never appear
page     -> map[allowUnplannedEvents:true propertiesRule:track-rules]
```

Dangerous, because computing a merge should not write into the source config at all - and there is no need for it to: the merge is two map lookups and an `lo.Assign`, recomputed per event today regardless, since the memo is written once per source copy and thrown away.

It does not misfire as things stand (one event per gateway batch, a fresh source copy per job), but `mergedTpConfig` is what decides whether an event is **dropped** - rudder-transformer dispatches `allowUnplannedEvents`, `unplannedProperties`, `anyOtherViolation` and `sendViolatedEventsTo` off it, per event - so the cost of it ever misfiring is event loss rather than noise.

`MergedConfig` is removed with it: never on the wire in either config version, and nothing outside the getter read it. `fetchEventConfig` goes too - it turned an absent key into an empty map, which `lo.Assign` does by itself.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
