### PR TITLE
chore: skip consent and connection-mode filtering for replays of non-existent connections

### DIFF
--- a/backend-config/replay_types.go
+++ b/backend-config/replay_types.go
@@ -113,7 +113,9 @@ func (c *ConfigT) destinationsBySourceType() map[string]map[string]*DestinationT
 // A replay does not have to name a source and a destination that were ever connected, so the
 // instance for that exact source may not exist. In that case the first source type in ascending
 // order is taken: an arbitrary choice, but a fixed one, where reading the destination out of a map
-// keyed by id alone would return whichever instance the map happened to hold.
+// keyed by id alone would return whichever instance the map happened to hold. Since that instance
+// was filtered for a different source type, some source-type-specific config keys are stripped from
+// a copy, so that we can operate against a "safe" config.
 func destinationForSourceType(byType map[string]*DestinationT, sourceType string) (*DestinationT, bool) {
 	if destination, ok := byType[sourceType]; ok {
 		return destination, true
@@ -127,5 +129,21 @@ func destinationForSourceType(byType map[string]*DestinationT, sourceType string
 			fallbackType, fallback = candidate, destination
 		}
 	}
-	return fallback, fallback != nil
+	if fallback == nil {
+		return nil, false
+	}
+	stripped := *fallback
+	stripped.Config = lo.OmitByKeys(fallback.Config, sourceTypeSpecificConfigKeys)
+	return &stripped, true
+}
+
+// sourceTypeSpecificConfigKeys are config keys whose values are specific to the source type the
+// destination instance was filtered for, so they are stripped from a fallback instance of a
+// different source type: when the replay is for a connection that never existed, we assume no
+// consent management filtering or event filtering based on connection mode should happen.
+var sourceTypeSpecificConfigKeys = []string{
+	"connectionMode",
+	"consentManagement",
+	"oneTrustCookieCategories",
+	"ketchConsentPurposes",
 }

--- a/backend-config/replay_types_test.go
+++ b/backend-config/replay_types_test.go
@@ -244,6 +244,28 @@ func TestApplyReplaySourcesDestinationConfig(t *testing.T) {
 		require.Equal(t, "web", replayed(t, c).Config["filteredFor"])
 	})
 
+	t.Run("the fallback instance loses its source-type-specific config keys", func(t *testing.T) {
+		// d-1 lives under a cloud source only; the replayed source is web, so the cloud instance is
+		// the fallback
+		c := config("")
+		c.Sources[0].Destinations[0].Config = map[string]any{
+			"filteredFor":              "cloud",
+			"connectionMode":           map[string]any{"cloud": "cloud"},
+			"consentManagement":        []any{map[string]any{"provider": "oneTrust"}},
+			"oneTrustCookieCategories": []any{"C0001"},
+			"ketchConsentPurposes":     []any{"analytics"},
+		}
+		c.Sources = append(c.Sources, SourceT{
+			ID:               "s-replayed",
+			SourceDefinition: SourceDefinitionT{Name: "Javascript"},
+		})
+		destination := replayed(t, c)
+
+		require.Equal(t, map[string]any{"filteredFor": "cloud"}, destination.Config)
+		require.Len(t, c.Sources[0].Destinations[0].Config, 5,
+			"the replay destination is a copy: stripping must not touch the original config")
+	})
+
 	t.Run("falls back to the first source type in order, and keeps falling back to the same one", func(t *testing.T) {
 		for range 20 { // the failure this guards against is a map iteration order flake
 			// d-1 is on a web and a cloud source; the replayed source is neither


### PR DESCRIPTION
# Description

When a replay targets a source and destination that were never connected, the destination config copied from another connection may carry source-type-specific keys (`connectionMode`, `consentManagement`, `oneTrustCookieCategories`, `ketchConsentPurposes`) filtered for a different source type. The fallback now strips these keys from a copy of the config, so no consent management or connection-mode event filtering applies to such replays.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
