### PR TITLE
fix(warehouse): stop logging full schemas on table-level schema mismatch

### DIFF
--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -113,7 +113,7 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) error 
 		)
 		if err != nil {
 			log.Errorn("Failed to update related schemas",
-				logger.NewStringField("schema", string(schemaPayload)),
+				logger.NewIntField("tables", int64(len(whSchema.Schema))),
 				obskit.Error(err),
 			)
 			return fmt.Errorf("updating related schemas: %w", err)
@@ -202,8 +202,8 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) error 
 				if err != nil {
 					log.Errorn("Failed to update table-level related schemas",
 						logger.NewStringField("tableName", tableName),
-						logger.NewStringField("schema", string(schemaPayload)),
-						logger.NewStringField("tableLevelSchema", string(tableSchemaPayload)),
+						logger.NewIntField("tables", int64(len(whSchema.Schema))),
+						logger.NewIntField("columns", int64(len(tableSchema))),
 						obskit.Error(err),
 					)
 					return fmt.Errorf("updating other table-level schemas for table %s: %w", tableName, err)

--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	"github.com/rudderlabs/rudder-go-kit/stringify"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
@@ -26,6 +25,9 @@ import (
 )
 
 const whSchemaTableName = warehouseutils.WarehouseSchemasTable
+
+// maxSchemaDiffLogSize caps the schema diff included in the mismatch warning.
+const maxSchemaDiffLogSize = 4 << 10
 
 const whSchemaTableColumns = `
 	id,
@@ -280,13 +282,19 @@ func (sh *WHSchema) GetForNamespace(ctx context.Context, destID, namespace strin
 	}
 	diff := cmp.Diff(originalSchema.Schema, tableLevelSchemas)
 	if len(diff) > 0 {
+		// Never log the schemas themselves: wide warehouses produce multi-MB
+		// lines that log collectors drop. Bound the diff for the same reason.
+		if len(diff) > maxSchemaDiffLogSize {
+			diff = diff[:maxSchemaDiffLogSize] + "...(truncated)"
+		}
 		sh.log.Warnn("Parent schema does not match",
 			obskit.Namespace(namespace),
 			obskit.DestinationID(destID),
-			logger.NewStringField("schema", stringify.Any(originalSchema.Schema)),
-			logger.NewStringField("tableLevelSchemas", stringify.Any(tableLevelSchemas)),
+			logger.NewIntField("parentTables", int64(len(originalSchema.Schema))),
+			logger.NewIntField("tableLevelTables", int64(len(tableLevelSchemas))),
+			logger.NewStringField("diff", diff),
 		)
-		return model.WHSchema{}, fmt.Errorf("parent schema does not match: %s", diff)
+		return model.WHSchema{}, errors.New("parent schema does not match")
 	}
 	return originalSchema, nil
 }

--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -646,6 +646,31 @@ func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 		require.Equal(t, now2, tableLevelSchemaCreatedAt.UTC())
 		require.Equal(t, now2, tableLevelSchemaUpdatedAt.UTC())
 	})
+	t.Run("Table-level schema drift", func(t *testing.T) {
+		conf := config.New()
+		conf.Set("Warehouse.enableTableLevelSchema", true)
+
+		db, ctx := setupDB(t), context.Background()
+		r := repo.NewWHSchemas(db, conf, logger.NOP)
+
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_1",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {"column_name_1": "string"},
+			},
+			ExpiresAt: time.Now().Add(time.Hour),
+		}))
+
+		// drift the table-level copy away from the parent
+		_, err := db.ExecContext(ctx, `UPDATE wh_schemas SET schema = '{"column_name_1":"int"}' WHERE destination_id = 'destination_id_1' AND namespace = 'namespace_1' AND table_name = 'table_name_1';`)
+		require.NoError(t, err)
+
+		_, err = r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
+		require.EqualError(t, err, "parent schema does not match")
+	})
 }
 
 func TestWHSchemasRepo_GetDestinationNamespaces(t *testing.T) {


### PR DESCRIPTION
# Description

`WHSchema.GetForNamespace` logs `Parent schema does not match` with **both** the parent schema and the table-level schemas serialized in full. For a wide warehouse (cloudwalk's BQ `rudderstack_dw` has thousands of `context_traits_*` / `all_cookies_*` columns) that is a ~19.9MB log line per occurrence. Loki rejects anything over `max_line_size` (10MB), so the warning never reached logs — and on the node it produced 142MB of container log for 7 lines in 30 minutes. The full `cmp.Diff` output was also embedded in the returned error.

Surfaced by the `LokiMaxLineSizeExceeded` alert on `infra1-us`; alloy-side mitigation in rudderlabs/rudder-devops#8149.

Changes in `warehouse/internal/repo/schema.go`:

- Log `parentTables` / `tableLevelTables` counts and the `cmp.Diff`, capped at 4KB, instead of the two schemas.
- Return a constant `parent schema does not match` error rather than one carrying the diff.
- Drop the now-unused `stringify` import.
- Same treatment for the two `Insert` failure logs (`Failed to update related schemas`, `Failed to update table-level related schemas`), which logged the full marshalled schema on any DB error and run per upload. They now log table/column counts.

Adds a `Table-level schema drift` case to `TestWHSchemasRepo_GetForNamespace`: the mismatch branch had no test before.

Not changed here: the mismatch is still a hard failure, so the affected destination's uploads keep aborting until the parent and table-level rows are reconciled. That is a separate decision for the warehouse team.

## Linear Ticket

None — originated from the `LokiMaxLineSizeExceeded` infra alert.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

## Validation

- `make fmt` — passed, no diff
- `go build ./warehouse/...` — passed
- `go test -count 1 -run TestWHSchemasRepo_GetForNamespace ./warehouse/internal/repo/` — passed (`ok  8.711s`)
- `golangci-lint v2.9.0 run ./warehouse/internal/repo/...` — 0 issues
- `git diff --check` — passed
