### PR TITLE
feat: backend config shadow mode

### DIFF
--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -3,6 +3,7 @@ package backendconfig
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -83,9 +84,22 @@ func (nc *namespaceConfig) SetUp() (err error) {
 		nc.logger = logger.NewLogger().Child("backend-config").Withn(obskit.Namespace(nc.namespace))
 	}
 
-	// the mode is fixed at setup. v2 is not selectable yet, see
-	// newV2ConfigFetcher
-	nc.fetcher = newV1ConfigFetcher(nc)
+	// the mode is fixed at setup: each fetcher owns its own incremental update state, so they
+	// cannot be swapped underneath a running poll loop
+	switch mode := nc.config.GetStringVar("v1", "BackendConfig.namespaceConfigMode"); mode {
+	case "v1":
+		nc.fetcher = newV1ConfigFetcher(nc)
+	case "v2":
+		if nc.fetcher, err = newV2ConfigFetcher(nc); err != nil {
+			return err
+		}
+	case "shadow": // v1 serves, v2 is fetched on the side and compared
+		if nc.fetcher, err = newShadowConfigFetcher(nc); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown namespace config mode %q", mode)
+	}
 
 	nc.logger.Infon("Setup backend config complete")
 

--- a/backend-config/namespace_config_shadow_comparer.go
+++ b/backend-config/namespace_config_shadow_comparer.go
@@ -1,0 +1,298 @@
+package backendconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"slices"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+)
+
+// shadowComparer compares the two sides of a sample and reports what it finds: counters for the
+// dashboard, and for a divergence the configs themselves, uploaded for offline inspection.
+type shadowComparer struct {
+	logger     logger.Logger
+	stats      stats.Stats
+	namespace  string
+	instanceID string
+
+	// nil when unconfigured: divergences are still counted and logged, only the artifacts are lost
+	uploader   shadowUploader
+	maxUploads config.ValueLoader[int]
+	uploaded   atomic.Int64
+
+	compared, matched, sampleDropped, turnSkipped stats.Counter
+	comparisonTime                                stats.Timer
+}
+
+func newShadowComparer(
+	conf *config.Config, log logger.Logger, stat stats.Stats, namespace string, uploader shadowUploader,
+) *shadowComparer {
+	return &shadowComparer{
+		logger:         log,
+		stats:          stat,
+		namespace:      namespace,
+		instanceID:     conf.GetStringVar("", "INSTANCE_ID"),
+		uploader:       uploader,
+		maxUploads:     conf.GetReloadableIntVar(5, 1, "BackendConfigShadow.maxUploads"),
+		compared:       stat.NewStat("bcv2_shadow_compared", stats.CountType),
+		matched:        stat.NewStat("bcv2_shadow_matched", stats.CountType),
+		sampleDropped:  stat.NewStat("bcv2_shadow_sample_dropped", stats.CountType),
+		turnSkipped:    stat.NewStat("bcv2_shadow_turn_skipped", stats.CountType),
+		comparisonTime: stat.NewStat("bcv2_shadow_comparison_time", stats.TimerType),
+	}
+}
+
+func (c *shadowComparer) compare(ctx context.Context, primary, candidate map[string]ConfigT) {
+	// membership is counted, not diffed: a workspace added or removed between the two fetches
+	// moves no timestamp, so the gate cannot catch it (§3.3.2 in design doc)
+	var diverging []string
+	for workspaceID, primaryConfig := range primary {
+		candidateConfig, ok := candidate[workspaceID]
+		if !ok {
+			c.membership("v1only")
+			continue
+		}
+		c.compared.Increment()
+		fields := divergingFields(shadowNormalize(primaryConfig), shadowNormalize(candidateConfig))
+		if len(fields) == 0 {
+			c.matched.Increment()
+			continue
+		}
+		for _, field := range fields {
+			c.diverged(field)
+		}
+		diverging = append(diverging, workspaceID)
+	}
+	for workspaceID := range candidate {
+		if _, ok := primary[workspaceID]; !ok {
+			c.membership("v2only")
+		}
+	}
+	if len(diverging) > 0 {
+		c.report(ctx, diverging, primary, candidate)
+	}
+}
+
+// shadowSample is the artifact a divergence uploads: the diverging workspaces from both sides -
+// never the whole namespace, which can run to hundreds of megabytes - and the diff of their
+// normalized forms, so the artifact is readable without a local replay.
+type shadowSample struct {
+	Namespace    string             `json:"namespace"`
+	WorkspaceIDs []string           `json:"workspaceIds"`
+	Diff         string             `json:"diff"`
+	V1           map[string]ConfigT `json:"v1"`
+	V2           map[string]ConfigT `json:"v2"`
+}
+
+func (c *shadowComparer) report(ctx context.Context, diverging []string, primary, candidate map[string]ConfigT) {
+	if c.uploader == nil {
+		c.logger.Warnn("shadow comparison diverged (no uploader configured)",
+			logger.NewIntField("workspaces", int64(len(diverging))))
+		return
+	}
+	// a systematic divergence diverges on every workspace of every sample; without a budget that
+	// is an unbounded write loop. Failed attempts refund it, so they cannot hide later, genuine
+	// divergences
+	if c.uploaded.Load() >= int64(c.maxUploads.Load()) {
+		return
+	}
+	c.uploaded.Add(1)
+
+	sample := shadowSample{
+		Namespace:    c.namespace,
+		WorkspaceIDs: diverging,
+		V1:           make(map[string]ConfigT, len(diverging)),
+		V2:           make(map[string]ConfigT, len(diverging)),
+	}
+	var diff bytes.Buffer
+	for _, workspaceID := range diverging {
+		sample.V1[workspaceID] = primary[workspaceID]
+		sample.V2[workspaceID] = candidate[workspaceID]
+		fmt.Fprintf(&diff, "workspace %s (-v1 +v2):\n%s\n", workspaceID,
+			configDiff(shadowNormalize(primary[workspaceID]), shadowNormalize(candidate[workspaceID])))
+	}
+	sample.Diff = diff.String()
+
+	payload, err := jsonrs.Marshal(sample)
+	if err == nil {
+		// the sample carries two full copies of every diverging workspace's config
+		payload, err = gzipped(payload)
+	}
+	if err != nil {
+		c.uploaded.Add(-1)
+		c.errored("encode")
+		c.logger.Errorn("shadow comparison cannot encode sample", obskit.Error(err))
+		return
+	}
+	// partitioned by day so a bucket lifecycle rule can expire old samples, and browsing during an
+	// incident starts from a date. The instance id keeps concurrently sampling pods off each
+	// other's keys, and names the pod that saw the divergence
+	now := time.Now().UTC()
+	objName := filepath.Join("bcv2-shadow-samples", now.Format("2006/01/02"), c.namespace,
+		fmt.Sprintf("%s-%s.json.gz", now.Format("150405"), c.instanceID))
+	file, err := c.uploader.UploadReader(ctx, objName, bytes.NewReader(payload))
+	if err != nil {
+		c.uploaded.Add(-1)
+		c.errored("upload")
+		c.logger.Errorn("shadow comparison sample upload failed", obskit.Error(err))
+		return
+	}
+	c.logger.Warnn("shadow comparison diverged",
+		logger.NewIntField("workspaces", int64(len(diverging))),
+		logger.NewStringField("location", file.Location),
+		logger.NewStringField("objectName", file.ObjectName),
+	)
+}
+
+func (c *shadowComparer) diverged(field string) {
+	c.stats.NewTaggedStat("bcv2_shadow_diverged", stats.CountType, stats.Tags{"field": field}).Increment()
+}
+
+func (c *shadowComparer) membership(side string) {
+	c.stats.NewTaggedStat("bcv2_shadow_membership", stats.CountType, stats.Tags{"side": side}).Increment()
+}
+
+func (c *shadowComparer) errored(reason string) {
+	c.stats.NewTaggedStat("bcv2_shadow_error", stats.CountType, stats.Tags{"reason": reason}).Increment()
+}
+
+func gzipped(payload []byte) ([]byte, error) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(payload); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return compressed.Bytes(), nil
+}
+
+// divergingFields names the top-level ConfigT fields on which the two sides differ, empty when
+// they agree.
+func divergingFields(primary, candidate ConfigT) []string {
+	reporter := &topLevelFieldReporter{fields: map[string]struct{}{}}
+	cmp.Equal(primary, candidate, append(shadowCmpOptions(), cmp.Reporter(reporter))...)
+	return slices.Sorted(maps.Keys(reporter.fields))
+}
+
+// configDiff renders the divergence between the two sides, for the uploaded artifact.
+func configDiff(primary, candidate ConfigT) string {
+	return cmp.Diff(primary, candidate, shadowCmpOptions()...)
+}
+
+// configCmpOptions compares two ConfigT documents by value rather than by bytes: v1's raw fields
+// arrive as the control plane serialized them, v2's are produced here, so identical configs are
+// almost never identical bytes. Slice order is nondeterministic on both sides, since the mapper
+// builds them by ranging Go maps. Shared between the shadow comparison and the fixture test.
+func configCmpOptions() cmp.Options {
+	return cmp.Options{
+		cmp.Transformer("rawJSON", func(raw json.RawMessage) any {
+			if len(raw) == 0 {
+				return nil
+			}
+			var value any
+			if err := jsonrs.Unmarshal(raw, &value); err != nil {
+				return string(raw)
+			}
+			return value
+		}),
+		cmpopts.SortSlices(func(a, b SourceT) bool { return a.ID < b.ID }),
+		cmpopts.SortSlices(func(a, b DestinationT) bool { return a.ID < b.ID }),
+		cmpopts.SortSlices(func(a, b TransformationT) bool { return a.ID < b.ID }),
+		// A12: the account definition catalogue is namespace global and is handed over whole,
+		// where v1 prunes it to what each workspace references purely to keep its copy small
+		cmpopts.IgnoreFields(ConfigT{}, "AccountDefinitions"),
+	}
+}
+
+// shadowCmpOptions is configCmpOptions for the live comparison, which must also ignore UpdatedAt:
+// the v1 endpoint moves it with the common config under incremental updates, so the two sides
+// disagree on it without either being wrong.
+func shadowCmpOptions() cmp.Options {
+	return append(configCmpOptions(), cmpopts.IgnoreFields(ConfigT{}, "UpdatedAt"))
+}
+
+// topLevelFieldReporter records, for every difference cmp finds, the ConfigT field it sits under.
+type topLevelFieldReporter struct {
+	path   cmp.Path
+	fields map[string]struct{}
+}
+
+func (r *topLevelFieldReporter) PushStep(step cmp.PathStep) { r.path = append(r.path, step) }
+func (r *topLevelFieldReporter) PopStep()                   { r.path = r.path[:len(r.path)-1] }
+
+func (r *topLevelFieldReporter) Report(result cmp.Result) {
+	if result.Equal() {
+		return
+	}
+	for _, step := range r.path {
+		if field, ok := step.(cmp.StructField); ok {
+			r.fields[field.Name()] = struct{}{}
+			return
+		}
+	}
+}
+
+// shadowNormalize returns the config with the fields the comparison must ignore blanked, on a
+// copy: the value handed in is the live config the rest of the process is using, and blanking it
+// in place would corrupt production config from the observability path. Sources and Connections
+// hold value types, so cloning the containers is what makes the blanking below safe.
+func shadowNormalize(config ConfigT) ConfigT {
+	config.Sources = slices.Clone(config.Sources)
+	config.Connections = maps.Clone(config.Connections)
+	// before the source configs are blanked: this one reads origin out of them
+	blankProfilesTableConnectionConfigs(&config)
+	blankEnrichedSourceConfigs(&config)
+	return config
+}
+
+// unenrichedSourceCategories are the source categories the control plane serves as stored. The
+// mapper maps every source the same way, but the control plane enriches cloud, singer-protocol and
+// warehouse source configs before serving them (credentials, resources, audiences), and that
+// enrichment is not ported (D2 in design doc) - so only the unenriched categories can be compared.
+// An allowlist, because enrichment dispatches on a mix of category and config.origin.
+var unenrichedSourceCategories = map[string]struct{}{"": {}, "webhook": {}}
+
+// blankEnrichedSourceConfigs clears the config of every source of an enriched category, where the
+// control plane's output differs from the mapper's pass-through by design.
+func blankEnrichedSourceConfigs(config *ConfigT) {
+	for i := range config.Sources {
+		if _, ok := unenrichedSourceCategories[config.Sources[i].SourceDefinition.Category]; !ok {
+			config.Sources[i].Config = nil
+		}
+	}
+}
+
+// blankProfilesTableConnectionConfigs clears the config of connections whose source is a profiles
+// table. B7's clause for those is enrichment dependent and is not ported, so the control plane
+// writes the source's table into them and the mapper does not.
+func blankProfilesTableConnectionConfigs(config *ConfigT) {
+	profilesTableSources := make(map[string]struct{})
+	for _, source := range config.Sources {
+		if jsonparser.GetStringOrEmpty(source.Config, "origin") == "profiles-table" {
+			profilesTableSources[source.ID] = struct{}{}
+		}
+	}
+	for id, connection := range config.Connections {
+		if _, ok := profilesTableSources[connection.SourceID]; ok {
+			connection.Config = nil
+			config.Connections[id] = connection
+		}
+	}
+}

--- a/backend-config/namespace_config_shadow_comparer.go
+++ b/backend-config/namespace_config_shadow_comparer.go
@@ -59,7 +59,7 @@ func newShadowComparer(
 
 func (c *shadowComparer) compare(ctx context.Context, primary, candidate map[string]ConfigT) {
 	// membership is counted, not diffed: a workspace added or removed between the two fetches
-	// moves no timestamp, so the gate cannot catch it (§3.3.2 in design doc)
+	// moves no timestamp, so the gate cannot catch it
 	var diverging []string
 	for workspaceID, primaryConfig := range primary {
 		candidateConfig, ok := candidate[workspaceID]
@@ -265,7 +265,7 @@ func shadowNormalize(config ConfigT) ConfigT {
 // unenrichedSourceCategories are the source categories the control plane serves as stored. The
 // mapper maps every source the same way, but the control plane enriches cloud, singer-protocol and
 // warehouse source configs before serving them (credentials, resources, audiences), and that
-// enrichment is not ported (D2 in design doc) - so only the unenriched categories can be compared.
+// enrichment is not ported - so only the unenriched categories can be compared.
 // An allowlist, because enrichment dispatches on a mix of category and config.origin.
 var unenrichedSourceCategories = map[string]struct{}{"": {}, "webhook": {}}
 

--- a/backend-config/namespace_config_shadow_fetcher.go
+++ b/backend-config/namespace_config_shadow_fetcher.go
@@ -1,0 +1,128 @@
+package backendconfig
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync/atomic"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+)
+
+// shadowConfigFetcher serves the primary fetcher's configs and, at most once per interval, fetches
+// the candidate's on the side and compares the two (§3.3 in design doc). The primary stays
+// authoritative: nothing the candidate does - an error, a panic, a divergence - reaches the
+// returned config, and the candidate is only fetched after the primary has returned, off the poll
+// goroutine, so the poll's latency is untouched.
+type shadowConfigFetcher struct {
+	primary   configFetcher
+	candidate shadowCandidate
+	logger    logger.Logger
+	comparer  *shadowComparer
+
+	interval time.Duration
+	lastRun  time.Time // touched only by the poll goroutine
+	// at most one comparison runs at a time: a poll that finds one still running skips its turn.
+	// The candidate keeps incremental state across samples, and this flag is also what orders
+	// that state between one sample goroutine and the next
+	sampling atomic.Bool
+}
+
+// shadowCandidate is the fetcher under observation. Beyond fetching, the sample gate needs to know
+// how fresh its definition catalogues are: a definition edit moves no workspace timestamp.
+type shadowCandidate interface {
+	configFetcher
+	definitionsUpdatedAt() time.Time
+}
+
+func newShadowConfigFetcher(nc *namespaceConfig) (*shadowConfigFetcher, error) {
+	candidate, err := newV2ConfigFetcher(nc)
+	if err != nil {
+		return nil, err
+	}
+	log := nc.logger.Withn(logger.NewStringField("component", "bcv2-shadow"))
+	uploader, err := newShadowSamplingUploader(nc.config, log)
+	if err != nil {
+		// degrade to counters and logs rather than blocking startup: only the artifacts are lost
+		uploader = nil
+		log.Errorn("shadow sampling uploader could not be created", obskit.Error(err))
+	}
+	return &shadowConfigFetcher{
+		primary:   newV1ConfigFetcher(nc),
+		candidate: candidate,
+		logger:    log,
+		interval:  nc.config.GetDurationVar(5, time.Minute, "BackendConfigShadow.samplingInterval"),
+		comparer:  newShadowComparer(nc.config, log, nc.stats, nc.namespace, uploader),
+	}, nil
+}
+
+// Get returns the primary's configs, and may leave a comparison of the two versions running
+// behind itself.
+func (f *shadowConfigFetcher) Get(ctx context.Context) (map[string]ConfigT, error) {
+	configs, err := f.primary.Get(ctx)
+	if err == nil {
+		f.sample(ctx, configs)
+	}
+	return configs, err
+}
+
+func (f *shadowConfigFetcher) sample(ctx context.Context, primary map[string]ConfigT) {
+	if time.Since(f.lastRun) < f.interval {
+		return
+	}
+	if !f.sampling.CompareAndSwap(false, true) {
+		f.comparer.turnSkipped.Increment() // an overrunning sample retries at the next poll
+		return
+	}
+	f.lastRun = time.Now()
+	// handing the primary's map to the goroutine is safe: every poll builds a fresh map and never
+	// mutates a previous one
+	go func() {
+		defer f.sampling.Store(false)
+		defer func() {
+			// the transform is young code, and this goroutine exists on the premise that the
+			// candidate cannot hurt the data plane
+			if r := recover(); r != nil {
+				f.comparer.errored("panic")
+				f.logger.Errorn("shadow comparison panicked",
+					logger.NewStringField("panic", fmt.Sprint(r)),
+					logger.NewStringField("stack", string(debug.Stack())),
+				)
+			}
+		}()
+		f.runSample(ctx, primary)
+	}()
+}
+
+func (f *shadowConfigFetcher) runSample(ctx context.Context, primary map[string]ConfigT) {
+	candidate, err := f.candidate.Get(ctx)
+	if err != nil {
+		f.comparer.errored("fetch") // the candidate has already logged the error itself
+		return
+	}
+	defer f.comparer.comparisonTime.RecordDuration()()
+	// anything written between the two fetches carries a timestamp later than everything the
+	// primary observed, making the sample incomparable (§3.3.2 in design doc). The candidate's
+	// side folds in the definition catalogues, which no workspace timestamp covers
+	candidateMax := newestUpdatedAt(candidate)
+	if definitions := f.candidate.definitionsUpdatedAt(); definitions.After(candidateMax) {
+		candidateMax = definitions
+	}
+	if candidateMax.After(newestUpdatedAt(primary)) {
+		f.comparer.sampleDropped.Increment()
+		return
+	}
+	f.comparer.compare(ctx, primary, candidate)
+}
+
+func newestUpdatedAt(configs map[string]ConfigT) time.Time {
+	var newest time.Time
+	for _, config := range configs {
+		if config.UpdatedAt.After(newest) {
+			newest = config.UpdatedAt
+		}
+	}
+	return newest
+}

--- a/backend-config/namespace_config_shadow_fetcher.go
+++ b/backend-config/namespace_config_shadow_fetcher.go
@@ -14,7 +14,7 @@ import (
 )
 
 // shadowConfigFetcher serves the primary fetcher's configs and, at most once per interval, fetches
-// the candidate's on the side and compares the two (§3.3 in design doc). The primary stays
+// the candidate's on the side and compares the two. The primary stays
 // authoritative: nothing the candidate does - an error, a panic, a divergence - reaches the
 // returned config, and the candidate is only fetched after the primary has returned, off the poll
 // goroutine, so all the poll pays is a shallow copy of the configs.
@@ -108,8 +108,8 @@ func (f *shadowConfigFetcher) runSample(ctx context.Context, primary map[string]
 	}
 	defer f.comparer.comparisonTime.RecordDuration()()
 	// anything written between the two fetches carries a timestamp later than everything the
-	// primary observed, making the sample incomparable (§3.3.2 in design doc). The candidate's
-	// side folds in the definition catalogues, which no workspace timestamp covers
+	// primary observed, making the sample incomparable. The candidate's side folds in the
+	// definition catalogues, which no workspace timestamp covers
 	candidateMax := newestUpdatedAt(candidate)
 	if definitions := f.candidate.definitionsUpdatedAt(); definitions.After(candidateMax) {
 		candidateMax = definitions

--- a/backend-config/namespace_config_shadow_fetcher.go
+++ b/backend-config/namespace_config_shadow_fetcher.go
@@ -3,7 +3,9 @@ package backendconfig
 import (
 	"context"
 	"fmt"
+	"maps"
 	"runtime/debug"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -15,7 +17,7 @@ import (
 // the candidate's on the side and compares the two (§3.3 in design doc). The primary stays
 // authoritative: nothing the candidate does - an error, a panic, a divergence - reaches the
 // returned config, and the candidate is only fetched after the primary has returned, off the poll
-// goroutine, so the poll's latency is untouched.
+// goroutine, so all the poll pays is a shallow copy of the configs.
 type shadowConfigFetcher struct {
 	primary   configFetcher
 	candidate shadowCandidate
@@ -77,8 +79,10 @@ func (f *shadowConfigFetcher) sample(ctx context.Context, primary map[string]Con
 		return
 	}
 	f.lastRun = time.Now()
-	// handing the primary's map to the goroutine is safe: every poll builds a fresh map and never
-	// mutates a previous one
+	// the caller is handed these very configs and does mutate them - configUpdate sorts every
+	// workspace's sources in place as soon as Get returns - so the comparison walks a copy of the
+	// containers, taken here, before the goroutine that reads them exists
+	primary = snapshotForComparison(primary)
 	go func() {
 		defer f.sampling.Store(false)
 		defer func() {
@@ -115,6 +119,18 @@ func (f *shadowConfigFetcher) runSample(ctx context.Context, primary map[string]
 		return
 	}
 	f.comparer.compare(ctx, primary, candidate)
+}
+
+// snapshotForComparison copies the containers the comparison walks. Only the containers: what
+// hangs below them is read by both sides and written by neither.
+func snapshotForComparison(configs map[string]ConfigT) map[string]ConfigT {
+	snapshot := make(map[string]ConfigT, len(configs))
+	for workspaceID, config := range configs {
+		config.Sources = slices.Clone(config.Sources)
+		config.Connections = maps.Clone(config.Connections)
+		snapshot[workspaceID] = config
+	}
+	return snapshot
 }
 
 func newestUpdatedAt(configs map[string]ConfigT) time.Time {

--- a/backend-config/namespace_config_shadow_test.go
+++ b/backend-config/namespace_config_shadow_test.go
@@ -1,0 +1,346 @@
+package backendconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+)
+
+func TestShadowConfigFetcher(t *testing.T) {
+	t0 := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+
+	t.Run("serves the primary untouched", func(t *testing.T) {
+		t.Run("result", func(t *testing.T) {
+			primary := &shadowFetcherStub{configs: map[string]ConfigT{"ws-1": {WorkspaceID: "ws-1"}}}
+			// the candidate's config differs from the primary's, so that the assertions below can
+			// tell which of the two sides was served
+			candidate := &shadowFetcherStub{configs: map[string]ConfigT{
+				"ws-1": {WorkspaceID: "ws-1", Sources: []SourceT{{ID: "s1"}}},
+			}}
+			fetcher, store := newShadowFetcherForTest(t, primary, candidate)
+
+			configs, err := fetcher.Get(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, primary.configs, configs)
+			require.NotEqual(t, candidate.configs, configs)
+			awaitSample(t, fetcher)
+			require.EqualValues(t, 1, candidate.calls.Load())
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_compared", nil))
+			timer := store.Get("bcv2_shadow_comparison_time", nil)
+			require.NotNil(t, timer, "the comparison is timed")
+			require.Len(t, timer.Durations(), 1)
+		})
+
+		t.Run("error, without spending a sample on it", func(t *testing.T) {
+			primary := &shadowFetcherStub{err: errors.New("boom")}
+			candidate := &shadowFetcherStub{}
+			fetcher, _ := newShadowFetcherForTest(t, primary, candidate)
+
+			_, err := fetcher.Get(context.Background())
+			require.ErrorContains(t, err, "boom")
+			// lastRun is written by the calling goroutine before a sample is launched, so an
+			// untouched one is proof no sample was started, where candidate.calls alone would
+			// race the sample goroutine into passing
+			require.True(t, fetcher.lastRun.IsZero(), "the failed poll did not spend a sample")
+			require.EqualValues(t, 0, candidate.calls.Load())
+		})
+	})
+
+	t.Run("sampling", func(t *testing.T) {
+		t.Run("at most once per interval", func(t *testing.T) {
+			primary := &shadowFetcherStub{configs: map[string]ConfigT{}}
+			candidate := &shadowFetcherStub{configs: map[string]ConfigT{}}
+			fetcher, store := newShadowFetcherForTest(t, primary, candidate)
+			fetcher.interval = time.Hour
+
+			_, _ = fetcher.Get(context.Background())
+			awaitSample(t, fetcher)
+			lastRun := fetcher.lastRun
+
+			_, _ = fetcher.Get(context.Background())
+			require.Equal(t, lastRun, fetcher.lastRun, "the second poll did not take a turn")
+			require.EqualValues(t, 1, candidate.calls.Load())
+			// within the interval is not a skipped turn, it is simply not the time to sample
+			require.Equal(t, 0.0, counterValue(store, "bcv2_shadow_turn_skipped", nil))
+		})
+
+		t.Run("skips its turn while a sample is in flight", func(t *testing.T) {
+			release := make(chan struct{})
+			primary := &shadowFetcherStub{configs: map[string]ConfigT{}}
+			candidate := &shadowFetcherStub{configs: map[string]ConfigT{}, release: release}
+			fetcher, store := newShadowFetcherForTest(t, primary, candidate)
+
+			_, _ = fetcher.Get(context.Background())
+			require.Eventually(t, func() bool { return candidate.calls.Load() == 1 },
+				time.Second, time.Millisecond)
+			_, _ = fetcher.Get(context.Background())
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_turn_skipped", nil))
+			require.EqualValues(t, 1, candidate.calls.Load())
+
+			close(release)
+			awaitSample(t, fetcher)
+		})
+
+		t.Run("recovers a panicking sample", func(t *testing.T) {
+			primary := &shadowFetcherStub{configs: map[string]ConfigT{}}
+			fetcher, store := newShadowFetcherForTest(t, primary, &panickingFetcher{})
+
+			_, err := fetcher.Get(context.Background())
+			require.NoError(t, err)
+			awaitSample(t, fetcher)
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_error", stats.Tags{"reason": "panic"}))
+		})
+
+		t.Run("counts a failing candidate fetch", func(t *testing.T) {
+			primary := &shadowFetcherStub{configs: map[string]ConfigT{}}
+			candidate := &shadowFetcherStub{err: errors.New("boom")}
+			fetcher, store := newShadowFetcherForTest(t, primary, candidate)
+
+			_, err := fetcher.Get(context.Background())
+			require.NoError(t, err)
+			awaitSample(t, fetcher)
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_error", stats.Tags{"reason": "fetch"}))
+		})
+	})
+
+	t.Run("gate", func(t *testing.T) {
+		gate := func(t *testing.T, candidate *shadowFetcherStub, dropped float64) {
+			t.Helper()
+			primary := map[string]ConfigT{"ws-1": {UpdatedAt: t0}}
+			fetcher, store := newShadowFetcherForTest(t, &shadowFetcherStub{}, candidate)
+			fetcher.runSample(context.Background(), primary)
+			require.Equal(t, dropped, counterValue(store, "bcv2_shadow_sample_dropped", nil))
+			require.Equal(t, 1-dropped, counterValue(store, "bcv2_shadow_compared", nil))
+		}
+
+		t.Run("a workspace written between the fetches drops the sample", func(t *testing.T) {
+			gate(t, &shadowFetcherStub{configs: map[string]ConfigT{"ws-1": {UpdatedAt: t0.Add(time.Second)}}}, 1)
+		})
+		t.Run("a definition written between the fetches drops the sample", func(t *testing.T) {
+			gate(t, &shadowFetcherStub{
+				configs: map[string]ConfigT{"ws-1": {UpdatedAt: t0}},
+				defs:    t0.Add(time.Second),
+			}, 1)
+		})
+		t.Run("unchanged state is compared", func(t *testing.T) {
+			gate(t, &shadowFetcherStub{configs: map[string]ConfigT{"ws-1": {UpdatedAt: t0}}, defs: t0}, 0)
+		})
+	})
+
+	t.Run("comparison", func(t *testing.T) {
+		t.Run("counts membership instead of diffing it", func(t *testing.T) {
+			store, comparer := newShadowComparerForTest(t, nil, nil)
+			comparer.compare(context.Background(),
+				map[string]ConfigT{"both": {}, "gone": {}},
+				map[string]ConfigT{"both": {}, "new": {}},
+			)
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_membership", stats.Tags{"side": "v1only"}))
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_membership", stats.Tags{"side": "v2only"}))
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_compared", nil))
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_matched", nil))
+		})
+
+		t.Run("byte level differences are not divergences", func(t *testing.T) {
+			uploader := &shadowUploaderStub{}
+			store, comparer := newShadowComparerForTest(t, nil, uploader)
+			comparer.compare(context.Background(),
+				map[string]ConfigT{"ws-1": {
+					UpdatedAt: t0, // ignored: v1 moves it with the common config, v2 does not
+					Sources:   []SourceT{{ID: "s1", Config: json.RawMessage(`{"a":1,"b":2}`)}},
+				}},
+				map[string]ConfigT{"ws-1": {
+					Sources: []SourceT{{ID: "s1", Config: json.RawMessage(`{"b": 2, "a": 1}`)}},
+				}},
+			)
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_matched", nil))
+			require.Empty(t, uploader.uploads)
+		})
+
+		t.Run("a divergence is counted by field and uploaded", func(t *testing.T) {
+			uploader := &shadowUploaderStub{}
+			store, comparer := newShadowComparerForTest(t, nil, uploader)
+			comparer.compare(context.Background(),
+				map[string]ConfigT{
+					"same":     {Libraries: LibrariesT{{VersionID: "v1"}}},
+					"diverged": {Sources: []SourceT{{ID: "s1", Name: "one"}}, Credentials: map[string]Credential{"k": {Key: "k"}}},
+				},
+				map[string]ConfigT{
+					"same":     {Libraries: LibrariesT{{VersionID: "v1"}}},
+					"diverged": {Sources: []SourceT{{ID: "s1", Name: "two"}}},
+				},
+			)
+			require.Equal(t, 2.0, counterValue(store, "bcv2_shadow_compared", nil))
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_matched", nil))
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_diverged", stats.Tags{"field": "Sources"}))
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_diverged", stats.Tags{"field": "Credentials"}))
+
+			require.Len(t, uploader.uploads, 1)
+			var sample shadowSample
+			reader, err := gzip.NewReader(bytes.NewReader(uploader.uploads[0]))
+			require.NoError(t, err)
+			payload, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.NoError(t, jsonrs.Unmarshal(payload, &sample))
+			require.Equal(t, "test-namespace", sample.Namespace)
+			require.Equal(t, []string{"diverged"}, sample.WorkspaceIDs)
+			require.Contains(t, sample.Diff, `"one"`, "the rendered diff carries the v1 value")
+			require.Contains(t, sample.Diff, `"two"`, "the rendered diff carries the v2 value")
+			require.Contains(t, sample.V1, "diverged")
+			require.Contains(t, sample.V2, "diverged")
+			require.Equal(t, "one", sample.V1["diverged"].Sources[0].Name, "v1 is the primary's config")
+			require.Equal(t, "two", sample.V2["diverged"].Sources[0].Name, "v2 is the candidate's config")
+			require.NotContains(t, sample.V1, "same", "only the diverging workspaces are uploaded")
+			require.NotContains(t, sample.V2, "same")
+
+			// the key is what a bucket lifecycle rule expires on, and what keeps two pods
+			// sampling the same namespace off each other's objects
+			require.Regexp(t,
+				`^bcv2-shadow-samples/\d{4}/\d{2}/\d{2}/test-namespace/\d{6}-test-instance\.json\.gz$`,
+				uploader.names[0])
+		})
+
+		t.Run("without an uploader a divergence is still counted", func(t *testing.T) {
+			store, comparer := newShadowComparerForTest(t, nil, nil)
+			comparer.compare(context.Background(),
+				map[string]ConfigT{"ws-1": {Sources: []SourceT{{ID: "s1"}}}},
+				map[string]ConfigT{"ws-1": {}},
+			)
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_diverged", stats.Tags{"field": "Sources"}))
+		})
+
+		t.Run("uploads stop at the budget", func(t *testing.T) {
+			conf := config.New()
+			conf.Set("BackendConfigShadow.maxUploads", 1)
+			uploader := &shadowUploaderStub{}
+			_, comparer := newShadowComparerForTest(t, conf, uploader)
+			diverging := map[string]ConfigT{"ws-1": {Sources: []SourceT{{ID: "s1"}}}}
+			comparer.compare(context.Background(), diverging, map[string]ConfigT{"ws-1": {}})
+			comparer.compare(context.Background(), diverging, map[string]ConfigT{"ws-1": {}})
+			require.Len(t, uploader.uploads, 1)
+		})
+
+		t.Run("a failed upload refunds the budget", func(t *testing.T) {
+			conf := config.New()
+			conf.Set("BackendConfigShadow.maxUploads", 1)
+			uploader := &shadowUploaderStub{err: errors.New("boom")}
+			store, comparer := newShadowComparerForTest(t, conf, uploader)
+			diverging := map[string]ConfigT{"ws-1": {Sources: []SourceT{{ID: "s1"}}}}
+			comparer.compare(context.Background(), diverging, map[string]ConfigT{"ws-1": {}})
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_error", stats.Tags{"reason": "upload"}))
+
+			uploader.err = nil // the failure must not have consumed the only slot
+			comparer.compare(context.Background(), diverging, map[string]ConfigT{"ws-1": {}})
+			require.Len(t, uploader.uploads, 1)
+		})
+	})
+
+	t.Run("shadowNormalize leaves the live config untouched", func(t *testing.T) {
+		live := ConfigT{
+			Sources: []SourceT{
+				{ID: "s1", SourceDefinition: SourceDefinitionT{Category: "cloud"}, Config: json.RawMessage(`{"origin":"profiles-table"}`)},
+				{ID: "s2", SourceDefinition: SourceDefinitionT{Category: "webhook"}, Config: json.RawMessage(`{"a":1}`)},
+			},
+			Connections: map[string]Connection{
+				"c1": {SourceID: "s1", Config: map[string]any{"table": "t"}},
+			},
+		}
+
+		normalized := shadowNormalize(live)
+		require.Nil(t, normalized.Sources[0].Config, "unported category: blanked")
+		require.NotNil(t, normalized.Sources[1].Config, "ported category: kept")
+		require.Nil(t, normalized.Connections["c1"].Config, "profiles-table connection: blanked")
+
+		require.NotNil(t, live.Sources[0].Config)
+		require.NotNil(t, live.Connections["c1"].Config)
+	})
+}
+
+// shadowFetcherStub is both a primary and a candidate: a candidate that blocks does so on release.
+type shadowFetcherStub struct {
+	configs map[string]ConfigT
+	err     error
+	defs    time.Time
+	calls   atomic.Int64
+	release chan struct{}
+}
+
+func (f *shadowFetcherStub) Get(context.Context) (map[string]ConfigT, error) {
+	f.calls.Add(1)
+	if f.release != nil {
+		<-f.release
+	}
+	return f.configs, f.err
+}
+
+func (f *shadowFetcherStub) definitionsUpdatedAt() time.Time { return f.defs }
+
+type panickingFetcher struct{}
+
+func (*panickingFetcher) Get(context.Context) (map[string]ConfigT, error) { panic("boom") }
+func (*panickingFetcher) definitionsUpdatedAt() time.Time                 { return time.Time{} }
+
+type shadowUploaderStub struct {
+	err     error
+	uploads [][]byte
+	names   []string
+}
+
+func (u *shadowUploaderStub) UploadReader(_ context.Context, objName string, rdr io.Reader) (filemanager.UploadedFile, error) {
+	if u.err != nil {
+		return filemanager.UploadedFile{}, u.err
+	}
+	payload, err := io.ReadAll(rdr)
+	if err != nil {
+		return filemanager.UploadedFile{}, err
+	}
+	u.uploads = append(u.uploads, payload)
+	u.names = append(u.names, objName)
+	return filemanager.UploadedFile{Location: "location", ObjectName: objName}, nil
+}
+
+func newShadowFetcherForTest(t *testing.T, primary configFetcher, candidate shadowCandidate) (*shadowConfigFetcher, *memstats.Store) {
+	t.Helper()
+	store, comparer := newShadowComparerForTest(t, nil, nil)
+	return &shadowConfigFetcher{logger: logger.NOP, primary: primary, candidate: candidate, comparer: comparer}, store
+}
+
+func newShadowComparerForTest(t *testing.T, conf *config.Config, uploader shadowUploader) (*memstats.Store, *shadowComparer) {
+	t.Helper()
+	store, err := memstats.New()
+	require.NoError(t, err)
+	if conf == nil {
+		conf = config.New()
+	}
+	conf.Set("INSTANCE_ID", "test-instance")
+	return store, newShadowComparer(conf, logger.NOP, store, "test-namespace", uploader)
+}
+
+// awaitSample waits for the in-flight sample, if any, to finish.
+func awaitSample(t *testing.T, fetcher *shadowConfigFetcher) {
+	t.Helper()
+	require.Eventually(t, func() bool { return !fetcher.sampling.Load() },
+		time.Second, time.Millisecond)
+}
+
+func counterValue(store *memstats.Store, name string, tags stats.Tags) float64 {
+	metric := store.Get(name, tags)
+	if metric == nil {
+		return 0
+	}
+	return metric.LastValue()
+}

--- a/backend-config/namespace_config_shadow_test.go
+++ b/backend-config/namespace_config_shadow_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"slices"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -58,6 +60,32 @@ func TestShadowConfigFetcher(t *testing.T) {
 			// race the sample goroutine into passing
 			require.True(t, fetcher.lastRun.IsZero(), "the failed poll did not spend a sample")
 			require.EqualValues(t, 0, candidate.calls.Load())
+		})
+
+		t.Run("and leaves it free to mutate what it was served", func(t *testing.T) {
+			release := make(chan struct{})
+			sources := []SourceT{{ID: "s2"}, {ID: "s1"}}
+			primary := &shadowFetcherStub{configs: map[string]ConfigT{
+				"ws-1": {WorkspaceID: "ws-1", Sources: sources},
+			}}
+			candidate := &shadowFetcherStub{configs: map[string]ConfigT{
+				"ws-1": {WorkspaceID: "ws-1", Sources: slices.Clone(sources)},
+			}, release: release}
+			fetcher, store := newShadowFetcherForTest(t, primary, candidate)
+
+			configs, err := fetcher.Get(context.Background())
+			require.NoError(t, err)
+			// the sample is released from a third goroutine, so that the sort below is ordered
+			// against neither the release nor the sample's reads: were the slices shared, this
+			// is the data race configUpdate makes on every poll
+			go close(release)
+			for _, config := range configs {
+				sort.Slice(config.Sources, func(i, j int) bool {
+					return config.Sources[i].ID < config.Sources[j].ID
+				})
+			}
+			awaitSample(t, fetcher)
+			require.Equal(t, 1.0, counterValue(store, "bcv2_shadow_matched", nil))
 		})
 	})
 

--- a/backend-config/namespace_config_shadow_uploader.go
+++ b/backend-config/namespace_config_shadow_uploader.go
@@ -1,0 +1,41 @@
+package backendconfig
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+// shadowUploader is the one method of filemanager.FileManager the comparer uses.
+type shadowUploader interface {
+	UploadReader(ctx context.Context, objName string, rdr io.Reader) (filemanager.UploadedFile, error)
+}
+
+// newShadowSamplingUploader returns the interface rather than the concrete manager: the caller
+// keys its degraded path on a nil uploader, which a typed nil pointer would defeat.
+func newShadowSamplingUploader(conf *config.Config, log logger.Logger) (shadowUploader, error) {
+	s3Config := map[string]any{
+		"bucketName":       conf.GetStringVar("backend-config-shadow-sampling", "BackendConfigShadow.Bucket"),
+		"endpoint":         conf.GetStringVar("", "BackendConfigShadow.Endpoint"),
+		"accessKeyID":      conf.GetStringVar("", "BackendConfigShadow.AccessKeyId", "AWS_ACCESS_KEY_ID"),
+		"accessKey":        conf.GetStringVar("", "BackendConfigShadow.AccessKey", "AWS_SECRET_ACCESS_KEY"),
+		"s3ForcePathStyle": conf.GetBoolVar(false, "BackendConfigShadow.S3ForcePathStyle"),
+		"disableSSL":       conf.GetBoolVar(false, "BackendConfigShadow.DisableSsl"),
+		"enableSSE":        conf.GetBoolVar(false, "BackendConfigShadow.EnableSse", "AWS_ENABLE_SSE"),
+		"useGlue":          conf.GetBoolVar(false, "BackendConfigShadow.UseGlue"),
+		"region":           conf.GetStringVar("us-east-1", "BackendConfigShadow.Region", "AWS_DEFAULT_REGION"),
+	}
+	manager, err := filemanager.NewS3Manager(conf, s3Config,
+		log.Withn(logger.NewStringField("component", "bcv2-shadow-uploader")),
+		func() time.Duration {
+			return conf.GetDurationVar(120, time.Second, "BackendConfigShadow.Timeout")
+		})
+	if err != nil {
+		return nil, err
+	}
+	return manager, nil
+}

--- a/backend-config/namespace_config_v2.go
+++ b/backend-config/namespace_config_v2.go
@@ -212,6 +212,11 @@ func (f *v2ConfigFetcher) memoized(workspaceID string, changed map[string]struct
 	return entry.config, true
 }
 
+// definitionsUpdatedAt is when the definition catalogues last changed, as of the latest Get.
+func (f *v2ConfigFetcher) definitionsUpdatedAt() time.Time {
+	return f.cache.generation().maxUpdatedAt
+}
+
 // v2Generation identifies a state of the definition catalogues, which every workspace is mapped
 // against. Cardinalities are part of it because a deletion bumps no timestamp.
 //

--- a/backend-config/namespace_config_v2_destconfig.go
+++ b/backend-config/namespace_config_v2_destconfig.go
@@ -7,7 +7,7 @@ import (
 	"github.com/samber/lo"
 )
 
-// Per source destination config filtering (B3 in design doc).
+// Per source destination config filtering.
 //
 // The destination's config is not delivered as stored: it is rebuilt from the keys its definition
 // declares for the source type it is connected to, which is how a destination wired to a web
@@ -33,7 +33,7 @@ func filterDestinationConfig(stored, liveEventsConfig, definitionConfig map[stri
 		return nil, fmt.Errorf("definition destConfig has no defaultConfig list")
 	}
 
-	// the stored config and the live events flags are one object before any of this (A9 in design doc)
+	// the stored config and the live events flags are one object before any of this
 	unfiltered := lo.Assign(stored, liveEventsConfig)
 
 	filtered := make(map[string]any, len(defaultConfig))
@@ -118,7 +118,7 @@ func lodashSet(m map[string]any, path string, value any) {
 	m[segments[len(segments)-1]] = value
 }
 
-// Consent backfill, modern to legacy (B4 in design doc).
+// Consent backfill, modern to legacy.
 //
 // This is what keeps older SDK clients working against a destination configured in the modern UI.
 // processor/consent.go picks its branch from the event: an event whose context.consentManagement

--- a/backend-config/namespace_config_v2_fixture_test.go
+++ b/backend-config/namespace_config_v2_fixture_test.go
@@ -1,7 +1,6 @@
 package backendconfig
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
@@ -61,18 +59,9 @@ func TestV2MapperAgainstFixtures(t *testing.T) {
 			t.Logf("sources %d, destinations %d, connections %d",
 				len(actual.Sources), countDestinations(actual), len(actual.Connections))
 
-			// source enrichment is a rudder-sources concern and is not ported (D2), so the config
-			// of an enrichment category source differs by design: the control plane resolves
-			// account credentials into it, we pass the stored config through. Compared for the
-			// categories that are ported, blanked for the rest - an allowlist, because enrichment
-			// dispatches on a mix of category and definition name
-			// before the source configs are blanked: this one reads origin out of them
-			blankProfilesTableConnectionConfigs(expected)
-			blankProfilesTableConnectionConfigs(&actual)
-			blankUnportedSourceConfigs(expected)
-			blankUnportedSourceConfigs(&actual)
-
-			if diff := cmp.Diff(*expected, actual, fixtureCmpOptions()...); diff != "" {
+			// normalized exactly as the live shadow comparison normalizes, which also makes this
+			// the one place shadowNormalize meets production shaped data
+			if diff := cmp.Diff(shadowNormalize(*expected), shadowNormalize(actual), configCmpOptions()...); diff != "" {
 				t.Errorf("mapped config differs from the v1 capture (-v1 +v2):\n%s", diff)
 			}
 		})
@@ -114,68 +103,10 @@ func fixture(t *testing.T, version string) []byte {
 	return body
 }
 
-// portedSourceCategories are the source categories whose Config the mapper reproduces. Everything
-// else reaches rudder-server enriched by the control plane.
-var portedSourceCategories = map[string]struct{}{"": {}, "webhook": {}}
-
-// blankUnportedSourceConfigs clears the config of every source whose category is not ported. It
-// works on the slice the caller owns, which is fine here: these ConfigT values are the test's own.
-// The shadow mode equivalent must copy first - there the value is the live config.
-func blankUnportedSourceConfigs(config *ConfigT) {
-	for i := range config.Sources {
-		if _, ok := portedSourceCategories[config.Sources[i].SourceDefinition.Category]; !ok {
-			config.Sources[i].Config = nil
-		}
-	}
-}
-
-// blankProfilesTableConnectionConfigs clears the config of connections whose source is a profiles
-// table. B7's clause for those is enrichment dependent and is not ported, so the control plane
-// writes the source's table into them and we do not.
-func blankProfilesTableConnectionConfigs(config *ConfigT) {
-	profilesTableSources := make(map[string]struct{})
-	for _, source := range config.Sources {
-		if jsonparser.GetStringOrEmpty(source.Config, "origin") == "profiles-table" {
-			profilesTableSources[source.ID] = struct{}{}
-		}
-	}
-	for id, connection := range config.Connections {
-		if _, ok := profilesTableSources[connection.SourceID]; ok {
-			connection.Config = nil
-			config.Connections[id] = connection
-		}
-	}
-}
-
 func countDestinations(config ConfigT) int {
 	var count int
 	for _, source := range config.Sources {
 		count += len(source.Destinations)
 	}
 	return count
-}
-
-// fixtureCmpOptions compares the two documents by value rather than by bytes: v1's raw fields
-// arrive as the control plane serialized them, v2's are produced here, so identical configs are
-// almost never identical bytes. Slice order is nondeterministic on both sides, since the mapper
-// builds them by ranging Go maps.
-func fixtureCmpOptions() cmp.Options {
-	return cmp.Options{
-		cmp.Transformer("rawJSON", func(raw json.RawMessage) any {
-			if len(raw) == 0 {
-				return nil
-			}
-			var value any
-			if err := jsonrs.Unmarshal(raw, &value); err != nil {
-				return string(raw)
-			}
-			return value
-		}),
-		cmpopts.SortSlices(func(a, b SourceT) bool { return a.ID < b.ID }),
-		cmpopts.SortSlices(func(a, b DestinationT) bool { return a.ID < b.ID }),
-		cmpopts.SortSlices(func(a, b TransformationT) bool { return a.ID < b.ID }),
-		// A12: the account definition catalogue is namespace global and is handed over whole,
-		// where v1 prunes it to what each workspace references purely to keep its copy small
-		cmpopts.IgnoreFields(ConfigT{}, "AccountDefinitions"),
-	}
 }

--- a/backend-config/namespace_config_v2_mapper.go
+++ b/backend-config/namespace_config_v2_mapper.go
@@ -48,7 +48,7 @@ func (m *configMapper) Map(workspaceID string, raw json.RawMessage, catalogues v
 		return ConfigT{}, fmt.Errorf("unmarshalling workspace: %w", err)
 	}
 
-	// v1 nests destinations under sources, v2 joins them through connections (A7 in design doc).
+	// v1 nests destinations under sources, v2 joins them through connections.
 	// Ranged in id order, here and over the sources below, for a repeatable output: configUpdate
 	// compares each poll's result with the previous one.
 	connectionsBySource := make(map[string][]Connection, len(workspace.Sources))
@@ -67,15 +67,15 @@ func (m *configMapper) Map(workspaceID string, raw json.RawMessage, catalogues v
 		sources = append(sources, mapped)
 	}
 
-	// connections are emitted as they are, minus the ones whose destination was skipped (B7 in design doc)
+	// connections are emitted as they are, minus the ones whose destination was skipped
 	connections := lo.OmitBy(workspace.Connections, func(_ string, c Connection) bool {
 		_, skipped := skippedDestinations[c.DestinationID]
 		return skipped
 	})
 
-	// pass-throughs (A11 in design doc). The account definition catalogue is kept whole
-	// (A12 in design doc) - v1 prunes it to what the workspace references, purely to keep its
-	// per-workspace copy small
+	// Libraries, EventReplays, Credentials and Accounts below are pass-throughs. The account
+	// definition catalogue is kept whole - v1 prunes it to what the workspace references, purely
+	// to keep its per-workspace copy small
 	accountDefinitions := lo.MapValues(catalogues.AccountDefinitions,
 		func(definition v2AccountDefinition, name string) AccountDefinition { return definition.toV1(name) })
 
@@ -114,7 +114,7 @@ func (m *configMapper) mapSource(
 	connections []Connection,
 	skippedDestinations map[string]struct{},
 ) (SourceT, error) {
-	// definitions are catalogued by name and carry none of their own (A3 in design doc)
+	// definitions are catalogued by name and carry none of their own
 	definition, ok := catalogues.SourceDefinitions[source.SourceDefinitionName]
 	if !ok {
 		return SourceT{}, fmt.Errorf("source %q references unknown source definition %q", sourceID, source.SourceDefinitionName)
@@ -126,15 +126,15 @@ func (m *configMapper) mapSource(
 		return SourceT{}, err
 	}
 
-	// the flat config and liveEventsConfig are merged into one object (A4 in design doc)
+	// the flat config and liveEventsConfig are merged into one object
 	config, err := jsonrs.Marshal(lo.Assign(source.Config, source.LiveEventsConfig))
 	if err != nil {
 		return SourceT{}, fmt.Errorf("marshalling config of source %q: %w", sourceID, err)
 	}
 
 	mapped := SourceT{
-		ID:               sourceID,    // the map key is the id (A2 in design doc)
-		WorkspaceID:      workspaceID, // and the workspace's key is the workspace id (A2 in design doc)
+		ID:               sourceID,    // the map key is the id
+		WorkspaceID:      workspaceID, // and the workspace's key is the workspace id
 		Name:             source.Name,
 		SourceDefinition: sourceDefinition,
 		Config:           config,
@@ -142,13 +142,13 @@ func (m *configMapper) mapSource(
 		Destinations:     destinations,
 		WriteKey:         source.WriteKey,
 		Transient:        source.Transient,
-		InternalSecret:   source.InternalSecret, // load bearing: the hydrate path forwards it (A14 in design doc)
+		InternalSecret:   source.InternalSecret, // load bearing: the hydrate path forwards it
 	}
-	// truthy, not nullish - an absent geoEnrichment is disabled (A5 in design doc)
+	// truthy, not nullish - an absent geoEnrichment is disabled
 	mapped.GeoEnrichment.Enabled = lo.FromPtr(source.GeoEnrichment).Enabled
 
 	// the tracking plan is attached only to a source that has one, enabled and not deleted, and
-	// only when the plan it names exists in this workspace (A6 in design doc)
+	// only when the plan it names exists in this workspace
 	if plan := source.DgSourceTrackingPlanConfig; plan != nil {
 		mapped.DgSourceTrackingPlanConfig = DgSourceTrackingPlanConfigT{
 			SourceId:            sourceID,
@@ -189,11 +189,11 @@ func (m *configMapper) mapDestinations(
 		}
 
 		// the definition this destination is delivered with carries the config of the major it is
-		// pinned to, which may be an archived one (B2 in design doc)
+		// pinned to, which may be an archived one
 		definitionV1, major, err := definition.toV1(destination.DestinationDefinitionName, destination.Version)
 		if errors.Is(err, errUnknownVersion) {
 			// skip the row rather than fail the workspace, and let the connection pruning drop its
-			// connection with it (B7 in design doc)
+			// connection with it
 			skippedDestinations[connection.DestinationID] = struct{}{}
 			m.reportUnresolvable(workspaceID, connection.DestinationID, destination, major)
 			continue
@@ -202,13 +202,12 @@ func (m *configMapper) mapDestinations(
 		}
 
 		// the config is rebuilt from the keys the definition declares for this source's type
-		// (B3 in design doc)
 		config, err := filterDestinationConfig(destination.Config, destination.LiveEventsConfig,
 			definitionV1.Config, sourceTypeOf(sourceDefinition.Name, sourceDefinition.Category))
 		if err != nil {
 			return nil, fmt.Errorf("filtering config of destination %q: %w", connection.DestinationID, err)
 		}
-		// the legacy consent keys are backfilled last, from the config just rebuilt (B4 in design doc)
+		// the legacy consent keys are backfilled last, from the config just rebuilt
 		config = backfillLegacyConsents(config)
 
 		mapped := DestinationT{
@@ -219,12 +218,12 @@ func (m *configMapper) mapDestinations(
 			WorkspaceID:        workspaceID,
 			IsProcessorEnabled: connection.ProcessorEnabled,
 			RevisionID:         destination.RevisionID,
-			// the major its definition was resolved for (A10 in design doc)
+			// the major its definition was resolved for
 			Version:               major,
 			DestinationDefinition: definitionV1,
 		}
 
-		// the slice is always there, empty included, as v1 serializes it (A8 in design doc)
+		// the slice is always there, empty included, as v1 serializes it
 		mapped.Transformations, err = lo.MapErr(destination.TransformationIDs,
 			func(transformationID string, _ int) (TransformationT, error) {
 				transformation, ok := workspace.Transformations[transformationID]


### PR DESCRIPTION
# Description

Introducing shadow mode for the namespace config, through a mode selector: `BackendConfig.namespaceConfigMode` = `v1` (default) | `v2` | `shadow`.

In shadow mode v1 remains authoritative but at most once per interval (default 5m), after a successful v1 poll, v2 is fetched and compared on its own goroutine. There is always at most one comparison in flight at a time, panics are contained and errors are counted but not propagated. A v2 sample ahead of its v1 counterpart (in terms of `updatedAt`) is ignored rather than reported.

## Notes

- The comparison runs on normalized **copies**: enriched-category source configs and profiles-table connection configs are blanked (enrichment is not ported by design), `UpdatedAt` and `AccountDefinitions` are ignored. Same exclusions the fixture test already used — they now live in one place, shared by both.
- Divergences are counted per top-level `ConfigT` field (`bcv2_shadow_*` stats) and the diverging workspaces are uploaded to S3 (`BackendConfigShadow.*` config), budgeted at 5 uploads; a missing bucket degrades to counters and logs, it doesn't block the startup.

## Linear Ticket

resolves PIPE-3280

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
