### PR TITLE
refactor(processor): assemble side-PU report metrics at end of preprocess stage

### DIFF
--- a/integration_test/srchydration/src_hydration_test.go
+++ b/integration_test/srchydration/src_hydration_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -413,7 +414,10 @@ func prepareExpectedReports(t *testing.T, sourceId string, gwOnly bool, numEvent
 
 func requireReports(t *testing.T, ctx context.Context, db *sql.DB, expectedReports []reportRow) {
 	t.Helper()
-	// multiple rows can be recorded for the same report key, so aggregate their counts
+	// multiple rows can be recorded for the same report key, so aggregate their counts.
+	// Order by the report key itself, not insertion order (MIN(id)): rows for different
+	// PUs of the same batch are appended to reportMetrics in an order that is not part of
+	// the reporting contract.
 	query := `
 					SELECT
 					  workspace_id, instance_id, source_id, destination_id,
@@ -424,10 +428,10 @@ func requireReports(t *testing.T, ctx context.Context, db *sql.DB, expectedRepor
 					GROUP BY
 					  workspace_id, instance_id, source_id, destination_id,
 					  in_pu, pu, status_code, status,
-					  terminal_state, initial_state, source_category, event_type
-					ORDER BY
-					  source_id, MIN(id);
+					  terminal_state, initial_state, source_category, event_type;
 				`
+	expectedReports = append([]reportRow(nil), expectedReports...)
+	slices.SortFunc(expectedReports, compareReportRows)
 	require.Eventuallyf(t, func() bool {
 		rows, err := db.QueryContext(ctx, query)
 		if err != nil {
@@ -454,9 +458,31 @@ func requireReports(t *testing.T, ctx context.Context, db *sql.DB, expectedRepor
 			actualReports = append(actualReports, r)
 		}
 		require.NoError(t, rows.Err())
+		slices.SortFunc(actualReports, compareReportRows)
 		require.Equal(t, expectedReports, actualReports)
 		return true
 	}, 1*time.Minute, 5*time.Second, "reporting data mismatch")
+}
+
+// compareReportRows orders rows by their report key so assertions don't depend on the
+// order rows were inserted into the reports table.
+func compareReportRows(a, b reportRow) int {
+	if c := strings.Compare(a.SourceID, b.SourceID); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.DestinationID, b.DestinationID); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.PU, b.PU); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.InPU, b.InPU); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.Status, b.Status); c != 0 {
+		return c
+	}
+	return a.StatusCode - b.StatusCode
 }
 
 func prepareBackendConfigServer(t *testing.T, webhookURL string, internalSecret json.RawMessage) *httptest.Server {

--- a/processor/assemble_side_metrics_test.go
+++ b/processor/assemble_side_metrics_test.go
@@ -9,11 +9,14 @@ import (
 	reportingtypes "github.com/rudderlabs/rudder-server/utils/types"
 )
 
+// assembleTestConnKey is the single connection key used across these tests.
+const assembleTestConnKey = "conn1"
+
 // statusDetailsMapWith builds a single-connection, single-event status-details map, the
 // shape assembleSideStatusDetailMetrics expects for each of its eight map arguments.
-func statusDetailsMapWith(connKey, eventName string, count int64) map[string]map[string]*reportingtypes.StatusDetail {
+func statusDetailsMapWith(eventName string, count int64) map[string]map[string]*reportingtypes.StatusDetail {
 	return map[string]map[string]*reportingtypes.StatusDetail{
-		connKey: {
+		assembleTestConnKey: {
 			eventName: {
 				Status:    "succeeded",
 				Count:     count,
@@ -25,7 +28,6 @@ func statusDetailsMapWith(connKey, eventName string, count int64) map[string]map
 }
 
 func TestAssembleSideStatusDetailMetrics(t *testing.T) {
-	const connKey = "conn1"
 	cd := &reportingtypes.ConnectionDetails{SourceID: "src1", DestinationID: "dest1"}
 
 	t.Run("each status-details map produces rows under its own PU", func(t *testing.T) {
@@ -105,8 +107,8 @@ func TestAssembleSideStatusDetailMetrics(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				connectionDetailsMap := map[string]*reportingtypes.ConnectionDetails{connKey: cd}
-				populated := statusDetailsMapWith(connKey, "evt", 5)
+				connectionDetailsMap := map[string]*reportingtypes.ConnectionDetails{assembleTestConnKey: cd}
+				populated := statusDetailsMapWith("evt", 5)
 				empty := map[string]map[string]*reportingtypes.StatusDetail{}
 
 				args := map[string]map[string]map[string]*reportingtypes.StatusDetail{
@@ -136,26 +138,26 @@ func TestAssembleSideStatusDetailMetrics(t *testing.T) {
 
 				require.Len(t, metrics, 1)
 				require.Equal(t, *cd, metrics[0].ConnectionDetails)
-				require.Equal(t, tc.expectedInPU, metrics[0].PUDetails.InPU)
-				require.Equal(t, tc.expectedPU, metrics[0].PUDetails.PU)
-				require.Equal(t, tc.expectedInitial, metrics[0].PUDetails.InitialPU)
-				require.Equal(t, tc.expectedTerminal, metrics[0].PUDetails.TerminalPU)
+				require.Equal(t, tc.expectedInPU, metrics[0].InPU)
+				require.Equal(t, tc.expectedPU, metrics[0].PU)
+				require.Equal(t, tc.expectedInitial, metrics[0].InitialPU)
+				require.Equal(t, tc.expectedTerminal, metrics[0].TerminalPU)
 				require.Equal(t, int64(5), metrics[0].StatusDetail.Count)
 			})
 		}
 	})
 
 	t.Run("all eight maps populated for one connection key emit exactly eight rows, one per PU, with counts carried through", func(t *testing.T) {
-		connectionDetailsMap := map[string]*reportingtypes.ConnectionDetails{connKey: cd}
+		connectionDetailsMap := map[string]*reportingtypes.ConnectionDetails{assembleTestConnKey: cd}
 
-		statusDetailsMap := statusDetailsMapWith(connKey, "gw-evt", 1)
-		enricherStatusDetailsMap := statusDetailsMapWith(connKey, "enricher-evt", 2)
-		botManagementStatusDetailsMap := statusDetailsMapWith(connKey, "bot-evt", 3)
-		eventBlockingStatusDetailsMap := statusDetailsMapWith(connKey, "block-evt", 4)
-		userSuppressionStatusDetailsMap := statusDetailsMapWith(connKey, "suppress-evt", 5)
-		dedupStatusDetailsMap := statusDetailsMapWith(connKey, "dedup-evt", 6)
-		gatewayIngestedStatusDetailsMap := statusDetailsMapWith(connKey, "ingest-evt", 7)
-		destFilterStatusDetailMap := statusDetailsMapWith(connKey, "filter-evt", 8)
+		statusDetailsMap := statusDetailsMapWith("gw-evt", 1)
+		enricherStatusDetailsMap := statusDetailsMapWith("enricher-evt", 2)
+		botManagementStatusDetailsMap := statusDetailsMapWith("bot-evt", 3)
+		eventBlockingStatusDetailsMap := statusDetailsMapWith("block-evt", 4)
+		userSuppressionStatusDetailsMap := statusDetailsMapWith("suppress-evt", 5)
+		dedupStatusDetailsMap := statusDetailsMapWith("dedup-evt", 6)
+		gatewayIngestedStatusDetailsMap := statusDetailsMapWith("ingest-evt", 7)
+		destFilterStatusDetailMap := statusDetailsMapWith("filter-evt", 8)
 
 		proc := &Handle{}
 		metrics := proc.assembleSideStatusDetailMetrics(
@@ -198,10 +200,10 @@ func TestAssembleSideStatusDetailMetrics(t *testing.T) {
 			seen[eventName] = true
 
 			require.Equal(t, *cd, m.ConnectionDetails, "connection details for %q", eventName)
-			require.Equal(t, exp.inPU, m.PUDetails.InPU, "inPU for %q", eventName)
-			require.Equal(t, exp.pu, m.PUDetails.PU, "PU for %q", eventName)
-			require.Equal(t, exp.initial, m.PUDetails.InitialPU, "initial for %q", eventName)
-			require.Equal(t, exp.terminal, m.PUDetails.TerminalPU, "terminal for %q", eventName)
+			require.Equal(t, exp.inPU, m.InPU, "inPU for %q", eventName)
+			require.Equal(t, exp.pu, m.PU, "PU for %q", eventName)
+			require.Equal(t, exp.initial, m.InitialPU, "initial for %q", eventName)
+			require.Equal(t, exp.terminal, m.TerminalPU, "terminal for %q", eventName)
 			require.Equal(t, exp.count, m.StatusDetail.Count, "count for %q", eventName)
 		}
 		require.Len(t, seen, 8)
@@ -211,9 +213,9 @@ func TestAssembleSideStatusDetailMetrics(t *testing.T) {
 		sort.Slice(metrics, func(i, j int) bool {
 			return metrics[i].StatusDetail.EventName < metrics[j].StatusDetail.EventName
 		})
-		metrics[0].ConnectionDetails.SourceID = "mutated"
+		metrics[0].SourceID = "mutated"
 		for i := 1; i < len(metrics); i++ {
-			require.Equal(t, "src1", metrics[i].ConnectionDetails.SourceID, "row %d must not observe mutation of row 0's ConnectionDetails", i)
+			require.Equal(t, "src1", metrics[i].SourceID, "row %d must not observe mutation of row 0's ConnectionDetails", i)
 		}
 	})
 }

--- a/processor/assemble_side_metrics_test.go
+++ b/processor/assemble_side_metrics_test.go
@@ -1,0 +1,219 @@
+package processor
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	reportingtypes "github.com/rudderlabs/rudder-server/utils/types"
+)
+
+// statusDetailsMapWith builds a single-connection, single-event status-details map, the
+// shape assembleSideStatusDetailMetrics expects for each of its eight map arguments.
+func statusDetailsMapWith(connKey, eventName string, count int64) map[string]map[string]*reportingtypes.StatusDetail {
+	return map[string]map[string]*reportingtypes.StatusDetail{
+		connKey: {
+			eventName: {
+				Status:    "succeeded",
+				Count:     count,
+				EventName: eventName,
+				EventType: "track",
+			},
+		},
+	}
+}
+
+func TestAssembleSideStatusDetailMetrics(t *testing.T) {
+	const connKey = "conn1"
+	cd := &reportingtypes.ConnectionDetails{SourceID: "src1", DestinationID: "dest1"}
+
+	t.Run("each status-details map produces rows under its own PU", func(t *testing.T) {
+		testCases := []struct {
+			name             string
+			mapName          string
+			expectedInPU     string
+			expectedPU       string
+			expectedInitial  bool
+			expectedTerminal bool
+		}{
+			{
+				name:             "statusDetailsMap emits a GATEWAY row",
+				mapName:          "statusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.GATEWAY,
+				expectedInitial:  true,
+				expectedTerminal: false,
+			},
+			{
+				name:             "enricherStatusDetailsMap emits under GATEWAY, not its own PU",
+				mapName:          "enricherStatusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.GATEWAY,
+				expectedInitial:  true,
+				expectedTerminal: false,
+			},
+			{
+				name:             "botManagementStatusDetailsMap emits a BOT_MANAGEMENT row",
+				mapName:          "botManagementStatusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.BOT_MANAGEMENT,
+				expectedInitial:  false,
+				expectedTerminal: false,
+			},
+			{
+				name:             "eventBlockingStatusDetailsMap emits an EVENT_BLOCKING row",
+				mapName:          "eventBlockingStatusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.EVENT_BLOCKING,
+				expectedInitial:  false,
+				expectedTerminal: false,
+			},
+			{
+				name:             "userSuppressionStatusDetailsMap emits a USER_SUPPRESSION row",
+				mapName:          "userSuppressionStatusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.USER_SUPPRESSION,
+				expectedInitial:  false,
+				expectedTerminal: false,
+			},
+			{
+				name:             "dedupStatusDetailsMap emits a DEDUP row",
+				mapName:          "dedupStatusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.DEDUP,
+				expectedInitial:  false,
+				expectedTerminal: false,
+			},
+			{
+				name:             "gatewayIngestedStatusDetailsMap emits a GATEWAY_INGESTED row",
+				mapName:          "gatewayIngestedStatusDetailsMap",
+				expectedInPU:     "",
+				expectedPU:       reportingtypes.GATEWAY_INGESTED,
+				expectedInitial:  false,
+				expectedTerminal: false,
+			},
+			{
+				name:             "destFilterStatusDetailMap emits a DESTINATION_FILTER row chained from GATEWAY",
+				mapName:          "destFilterStatusDetailMap",
+				expectedInPU:     reportingtypes.GATEWAY,
+				expectedPU:       reportingtypes.DESTINATION_FILTER,
+				expectedInitial:  false,
+				expectedTerminal: false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				connectionDetailsMap := map[string]*reportingtypes.ConnectionDetails{connKey: cd}
+				populated := statusDetailsMapWith(connKey, "evt", 5)
+				empty := map[string]map[string]*reportingtypes.StatusDetail{}
+
+				args := map[string]map[string]map[string]*reportingtypes.StatusDetail{
+					"statusDetailsMap":                empty,
+					"enricherStatusDetailsMap":        empty,
+					"botManagementStatusDetailsMap":   empty,
+					"eventBlockingStatusDetailsMap":   empty,
+					"userSuppressionStatusDetailsMap": empty,
+					"dedupStatusDetailsMap":           empty,
+					"gatewayIngestedStatusDetailsMap": empty,
+					"destFilterStatusDetailMap":       empty,
+				}
+				args[tc.mapName] = populated
+
+				proc := &Handle{}
+				metrics := proc.assembleSideStatusDetailMetrics(
+					connectionDetailsMap,
+					args["statusDetailsMap"],
+					args["enricherStatusDetailsMap"],
+					args["botManagementStatusDetailsMap"],
+					args["eventBlockingStatusDetailsMap"],
+					args["userSuppressionStatusDetailsMap"],
+					args["dedupStatusDetailsMap"],
+					args["gatewayIngestedStatusDetailsMap"],
+					args["destFilterStatusDetailMap"],
+				)
+
+				require.Len(t, metrics, 1)
+				require.Equal(t, *cd, metrics[0].ConnectionDetails)
+				require.Equal(t, tc.expectedInPU, metrics[0].PUDetails.InPU)
+				require.Equal(t, tc.expectedPU, metrics[0].PUDetails.PU)
+				require.Equal(t, tc.expectedInitial, metrics[0].PUDetails.InitialPU)
+				require.Equal(t, tc.expectedTerminal, metrics[0].PUDetails.TerminalPU)
+				require.Equal(t, int64(5), metrics[0].StatusDetail.Count)
+			})
+		}
+	})
+
+	t.Run("all eight maps populated for one connection key emit exactly eight rows, one per PU, with counts carried through", func(t *testing.T) {
+		connectionDetailsMap := map[string]*reportingtypes.ConnectionDetails{connKey: cd}
+
+		statusDetailsMap := statusDetailsMapWith(connKey, "gw-evt", 1)
+		enricherStatusDetailsMap := statusDetailsMapWith(connKey, "enricher-evt", 2)
+		botManagementStatusDetailsMap := statusDetailsMapWith(connKey, "bot-evt", 3)
+		eventBlockingStatusDetailsMap := statusDetailsMapWith(connKey, "block-evt", 4)
+		userSuppressionStatusDetailsMap := statusDetailsMapWith(connKey, "suppress-evt", 5)
+		dedupStatusDetailsMap := statusDetailsMapWith(connKey, "dedup-evt", 6)
+		gatewayIngestedStatusDetailsMap := statusDetailsMapWith(connKey, "ingest-evt", 7)
+		destFilterStatusDetailMap := statusDetailsMapWith(connKey, "filter-evt", 8)
+
+		proc := &Handle{}
+		metrics := proc.assembleSideStatusDetailMetrics(
+			connectionDetailsMap,
+			statusDetailsMap,
+			enricherStatusDetailsMap,
+			botManagementStatusDetailsMap,
+			eventBlockingStatusDetailsMap,
+			userSuppressionStatusDetailsMap,
+			dedupStatusDetailsMap,
+			gatewayIngestedStatusDetailsMap,
+			destFilterStatusDetailMap,
+		)
+
+		require.Len(t, metrics, 8)
+
+		expected := map[string]struct {
+			inPU     string
+			pu       string
+			initial  bool
+			terminal bool
+			count    int64
+		}{
+			"gw-evt":       {"", reportingtypes.GATEWAY, true, false, 1},
+			"enricher-evt": {"", reportingtypes.GATEWAY, true, false, 2},
+			"bot-evt":      {"", reportingtypes.BOT_MANAGEMENT, false, false, 3},
+			"block-evt":    {"", reportingtypes.EVENT_BLOCKING, false, false, 4},
+			"suppress-evt": {"", reportingtypes.USER_SUPPRESSION, false, false, 5},
+			"dedup-evt":    {"", reportingtypes.DEDUP, false, false, 6},
+			"ingest-evt":   {"", reportingtypes.GATEWAY_INGESTED, false, false, 7},
+			"filter-evt":   {reportingtypes.GATEWAY, reportingtypes.DESTINATION_FILTER, false, false, 8},
+		}
+
+		seen := make(map[string]bool, len(expected))
+		for _, m := range metrics {
+			eventName := m.StatusDetail.EventName
+			exp, ok := expected[eventName]
+			require.Truef(t, ok, "unexpected event name %q in emitted metrics", eventName)
+			require.False(t, seen[eventName], "duplicate row for event name %q", eventName)
+			seen[eventName] = true
+
+			require.Equal(t, *cd, m.ConnectionDetails, "connection details for %q", eventName)
+			require.Equal(t, exp.inPU, m.PUDetails.InPU, "inPU for %q", eventName)
+			require.Equal(t, exp.pu, m.PUDetails.PU, "PU for %q", eventName)
+			require.Equal(t, exp.initial, m.PUDetails.InitialPU, "initial for %q", eventName)
+			require.Equal(t, exp.terminal, m.PUDetails.TerminalPU, "terminal for %q", eventName)
+			require.Equal(t, exp.count, m.StatusDetail.Count, "count for %q", eventName)
+		}
+		require.Len(t, seen, 8)
+
+		// ConnectionDetails must be copied per row, not shared: mutating one row's
+		// ConnectionDetails must not leak into any other row.
+		sort.Slice(metrics, func(i, j int) bool {
+			return metrics[i].StatusDetail.EventName < metrics[j].StatusDetail.EventName
+		})
+		metrics[0].ConnectionDetails.SourceID = "mutated"
+		for i := 1; i < len(metrics); i++ {
+			require.Equal(t, "src1", metrics[i].ConnectionDetails.SourceID, "row %d must not observe mutation of row 0's ConnectionDetails", i)
+		}
+	})
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1801,29 +1801,20 @@ func (proc *Handle) eventAuditEnabled(workspaceID string) bool {
 }
 
 type preTransformationMessage struct {
-	partition                       string
-	subJobs                         subJob
-	eventSchemaJobsBySourceId       map[SourceIDT][]*jobsdb.JobT
-	archivalJobs                    []*jobsdb.JobT
-	connectionDetailsMap            map[string]*reportingtypes.ConnectionDetails
-	statusDetailsMap                map[string]map[string]*reportingtypes.StatusDetail
-	enricherStatusDetailsMap        map[string]map[string]*reportingtypes.StatusDetail
-	botManagementStatusDetailsMap   map[string]map[string]*reportingtypes.StatusDetail
-	eventBlockingStatusDetailsMap   map[string]map[string]*reportingtypes.StatusDetail
-	userSuppressionStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
-	dedupStatusDetailsMap           map[string]map[string]*reportingtypes.StatusDetail
-	gatewayIngestedStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
-	destFilterStatusDetailMap       map[string]map[string]*reportingtypes.StatusDetail
-	reportMetrics                   []*reportingtypes.PUReportedMetric
-	totalEvents                     int
-	groupedEventsBySourceId         map[SourceIDT][]types.TransformerEvent
-	eventsByMessageID               map[string]types.SingularEventWithReceivedAt
-	jobIDToSpecificDestMapOnly      map[int64]string
-	statusList                      []*jobsdb.JobStatusT
-	jobList                         []*jobsdb.JobT
-	sourceDupStats                  map[dupStatKey]int
-	dedupKeys                       map[string]struct{}
-	srcHydrationEnabledMap          map[SourceIDT]bool
+	partition                  string
+	subJobs                    subJob
+	eventSchemaJobsBySourceId  map[SourceIDT][]*jobsdb.JobT
+	archivalJobs               []*jobsdb.JobT
+	reportMetrics              []*reportingtypes.PUReportedMetric
+	totalEvents                int
+	groupedEventsBySourceId    map[SourceIDT][]types.TransformerEvent
+	eventsByMessageID          map[string]types.SingularEventWithReceivedAt
+	jobIDToSpecificDestMapOnly map[int64]string
+	statusList                 []*jobsdb.JobStatusT
+	jobList                    []*jobsdb.JobT
+	sourceDupStats             map[dupStatKey]int
+	dedupKeys                  map[string]struct{}
+	srcHydrationEnabledMap     map[SourceIDT]bool
 	// earlyDestinationFilter is the per-batch snapshot threaded from srcHydrationMessage; see the
 	// field doc on srcHydrationMessage.
 	earlyDestinationFilter bool
@@ -2369,31 +2360,136 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob, delay time
 	}
 	archivalJobs = nil
 
+	// REPORTING - side-PU status details assembly - START
+	// connectionDetailsMap and every side-PU statusDetailsMap above are only ever populated in
+	// the loop just above, so by this point (end of preprocessStage) they are already complete
+	// for the batch. Assemble them into PUReportedMetric rows here instead of threading nine
+	// separate map fields through srcHydrationMessage/preTransformationMessage down to
+	// pretransformStage.
+	if proc.isReportingEnabled() {
+		reportMetrics = append(reportMetrics, proc.assembleSideStatusDetailMetrics(
+			connectionDetailsMap,
+			statusDetailsMap,
+			enricherStatusDetailsMap,
+			botManagementStatusDetailsMap,
+			eventBlockingStatusDetailsMap,
+			userSuppressionStatusDetailsMap,
+			dedupStatusDetailsMap,
+			gatewayIngestedStatusDetailsMap,
+			destFilterStatusDetailMap,
+		)...)
+	}
+	// REPORTING - side-PU status details assembly - END
+
 	return &srcHydrationMessage{
-		partition:                       partition,
-		subJobs:                         subJobs,
-		eventSchemaJobsBySourceId:       eventSchemaJobsBySourceId,
-		archivalJobs:                    archivalJobs,
-		connectionDetailsMap:            connectionDetailsMap,
-		statusDetailsMap:                statusDetailsMap,
-		enricherStatusDetailsMap:        enricherStatusDetailsMap,
-		botManagementStatusDetailsMap:   botManagementStatusDetailsMap,
-		eventBlockingStatusDetailsMap:   eventBlockingStatusDetailsMap,
-		userSuppressionStatusDetailsMap: userSuppressionStatusDetailsMap,
-		dedupStatusDetailsMap:           dedupStatusDetailsMap,
-		gatewayIngestedStatusDetailsMap: gatewayIngestedStatusDetailsMap,
-		reportMetrics:                   reportMetrics,
-		destFilterStatusDetailMap:       destFilterStatusDetailMap,
-		totalEvents:                     totalEvents,
-		groupedEventsBySourceId:         groupedEventsBySourceId,
-		eventsByMessageID:               eventsByMessageID,
-		jobIDToSpecificDestMapOnly:      jobIDToSpecificDestMapOnly,
-		statusList:                      statusList,
-		jobList:                         jobList,
-		sourceDupStats:                  sourceDupStats,
-		dedupKeys:                       dedupKeys,
-		earlyDestinationFilter:          earlyDestinationFilter,
+		partition:                  partition,
+		subJobs:                    subJobs,
+		eventSchemaJobsBySourceId:  eventSchemaJobsBySourceId,
+		archivalJobs:               archivalJobs,
+		reportMetrics:              reportMetrics,
+		totalEvents:                totalEvents,
+		groupedEventsBySourceId:    groupedEventsBySourceId,
+		eventsByMessageID:          eventsByMessageID,
+		jobIDToSpecificDestMapOnly: jobIDToSpecificDestMapOnly,
+		statusList:                 statusList,
+		jobList:                    jobList,
+		sourceDupStats:             sourceDupStats,
+		dedupKeys:                  dedupKeys,
+		earlyDestinationFilter:     earlyDestinationFilter,
 	}, nil
+}
+
+// assembleSideStatusDetailMetrics converts the side-PU status-details maps accumulated in the
+// preprocess loop into PUReportedMetric rows. It requires connectionDetailsMap and every
+// statusDetailsMap argument to already be complete for the batch — callers must not invoke this
+// before the maps have stopped being written to.
+func (proc *Handle) assembleSideStatusDetailMetrics(
+	connectionDetailsMap map[string]*reportingtypes.ConnectionDetails,
+	statusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	enricherStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	botManagementStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	eventBlockingStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	userSuppressionStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	dedupStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	gatewayIngestedStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail,
+	destFilterStatusDetailMap map[string]map[string]*reportingtypes.StatusDetail,
+) []*reportingtypes.PUReportedMetric {
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, statusDetailsMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, destFilterStatusDetailMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, botManagementStatusDetailsMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, eventBlockingStatusDetailsMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, userSuppressionStatusDetailsMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, dedupStatusDetailsMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, gatewayIngestedStatusDetailsMap)
+	reportingtypes.AssertKeysSubset(connectionDetailsMap, enricherStatusDetailsMap)
+
+	metrics := make([]*reportingtypes.PUReportedMetric, 0)
+	for k, cd := range connectionDetailsMap {
+		for _, sd := range botManagementStatusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.BOT_MANAGEMENT, false, false),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, sd := range eventBlockingStatusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.EVENT_BLOCKING, false, false),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, sd := range userSuppressionStatusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.USER_SUPPRESSION, false, false),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, sd := range dedupStatusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.DEDUP, false, false),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, sd := range gatewayIngestedStatusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.GATEWAY_INGESTED, false, false),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, sd := range statusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.GATEWAY, false, true),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, sd := range enricherStatusDetailsMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.GATEWAY, false, true),
+				StatusDetail:      sd,
+			})
+		}
+
+		for _, dsd := range destFilterStatusDetailMap[k] {
+			metrics = append(metrics, &reportingtypes.PUReportedMetric{
+				ConnectionDetails: *cd,
+				PUDetails:         *reportingtypes.CreatePUDetails(reportingtypes.GATEWAY, reportingtypes.DESTINATION_FILTER, false, false),
+				StatusDetail:      dsd,
+			})
+		}
+	}
+	return metrics
 }
 
 func (proc *Handle) pretransformStage(partition string, preTrans *preTransformationMessage) (*transformationMessage, error) {
@@ -2447,87 +2543,11 @@ func (proc *Handle) pretransformStage(partition string, preTrans *preTransformat
 		return nil, err
 	}
 
-	// REPORTING - START
-	if proc.isReportingEnabled() {
-
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.statusDetailsMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.destFilterStatusDetailMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.botManagementStatusDetailsMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.eventBlockingStatusDetailsMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.userSuppressionStatusDetailsMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.dedupStatusDetailsMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.gatewayIngestedStatusDetailsMap)
-		reportingtypes.AssertKeysSubset(preTrans.connectionDetailsMap, preTrans.enricherStatusDetailsMap)
-
-		for k, cd := range preTrans.connectionDetailsMap {
-			for _, sd := range preTrans.botManagementStatusDetailsMap[k] {
-				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.BOT_MANAGEMENT, false, false),
-					StatusDetail:      sd,
-				})
-			}
-
-			for _, sd := range preTrans.eventBlockingStatusDetailsMap[k] {
-				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.EVENT_BLOCKING, false, false),
-					StatusDetail:      sd,
-				})
-			}
-
-			for _, sd := range preTrans.userSuppressionStatusDetailsMap[k] {
-				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.USER_SUPPRESSION, false, false),
-					StatusDetail:      sd,
-				})
-			}
-
-			for _, sd := range preTrans.dedupStatusDetailsMap[k] {
-				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.DEDUP, false, false),
-					StatusDetail:      sd,
-				})
-			}
-
-			for _, sd := range preTrans.gatewayIngestedStatusDetailsMap[k] {
-				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.GATEWAY_INGESTED, false, false),
-					StatusDetail:      sd,
-				})
-			}
-
-			for _, sd := range preTrans.statusDetailsMap[k] {
-				m := &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.GATEWAY, false, true),
-					StatusDetail:      sd,
-				}
-				preTrans.reportMetrics = append(preTrans.reportMetrics, m)
-			}
-
-			for _, sd := range preTrans.enricherStatusDetailsMap[k] {
-				preTrans.reportMetrics = append(preTrans.reportMetrics, &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails("", reportingtypes.GATEWAY, false, true),
-					StatusDetail:      sd,
-				})
-			}
-
-			for _, dsd := range preTrans.destFilterStatusDetailMap[k] {
-				destFilterMetric := &reportingtypes.PUReportedMetric{
-					ConnectionDetails: *cd,
-					PUDetails:         *reportingtypes.CreatePUDetails(reportingtypes.GATEWAY, reportingtypes.DESTINATION_FILTER, false, false),
-					StatusDetail:      dsd,
-				}
-				preTrans.reportMetrics = append(preTrans.reportMetrics, destFilterMetric)
-			}
-		}
-	}
-	// REPORTING - END
+	// REPORTING - the side-PU status-details maps (GATEWAY, BOT_MANAGEMENT, EVENT_BLOCKING,
+	// USER_SUPPRESSION, DEDUP, GATEWAY_INGESTED, DESTINATION_FILTER) are assembled into
+	// PUReportedMetric rows at the end of preprocessStage, as soon as connectionDetailsMap and
+	// those maps are complete for the batch — see assembleSideStatusDetailMetrics. They already
+	// arrive on preTrans.reportMetrics.
 
 	proc.stats.statNumEvents(preTrans.partition).Count(preTrans.totalEvents)
 

--- a/processor/src_hydration_stage.go
+++ b/processor/src_hydration_stage.go
@@ -26,28 +26,19 @@ import (
 )
 
 type srcHydrationMessage struct {
-	partition                       string
-	subJobs                         subJob
-	archivalJobs                    []*jobsdb.JobT
-	eventSchemaJobsBySourceId       map[SourceIDT][]*jobsdb.JobT
-	connectionDetailsMap            map[string]*reportingtypes.ConnectionDetails
-	statusDetailsMap                map[string]map[string]*reportingtypes.StatusDetail
-	enricherStatusDetailsMap        map[string]map[string]*reportingtypes.StatusDetail
-	botManagementStatusDetailsMap   map[string]map[string]*reportingtypes.StatusDetail
-	eventBlockingStatusDetailsMap   map[string]map[string]*reportingtypes.StatusDetail
-	userSuppressionStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
-	dedupStatusDetailsMap           map[string]map[string]*reportingtypes.StatusDetail
-	gatewayIngestedStatusDetailsMap map[string]map[string]*reportingtypes.StatusDetail
-	destFilterStatusDetailMap       map[string]map[string]*reportingtypes.StatusDetail
-	reportMetrics                   []*reportingtypes.PUReportedMetric
-	totalEvents                     int
-	groupedEventsBySourceId         map[SourceIDT][]types.TransformerEvent
-	eventsByMessageID               map[string]types.SingularEventWithReceivedAt
-	jobIDToSpecificDestMapOnly      map[int64]string
-	statusList                      []*jobsdb.JobStatusT
-	jobList                         []*jobsdb.JobT
-	sourceDupStats                  map[dupStatKey]int
-	dedupKeys                       map[string]struct{}
+	partition                  string
+	subJobs                    subJob
+	archivalJobs               []*jobsdb.JobT
+	eventSchemaJobsBySourceId  map[SourceIDT][]*jobsdb.JobT
+	reportMetrics              []*reportingtypes.PUReportedMetric
+	totalEvents                int
+	groupedEventsBySourceId    map[SourceIDT][]types.TransformerEvent
+	eventsByMessageID          map[string]types.SingularEventWithReceivedAt
+	jobIDToSpecificDestMapOnly map[int64]string
+	statusList                 []*jobsdb.JobStatusT
+	jobList                    []*jobsdb.JobT
+	sourceDupStats             map[dupStatKey]int
+	dedupKeys                  map[string]struct{}
 	// earlyDestinationFilter is a per-batch snapshot of Processor.earlyDestinationFilter taken
 	// once in preprocessStage, so that every stage this batch passes through observes the same
 	// value even if the reloadable config flips mid-flight.
@@ -166,30 +157,21 @@ func (proc *Handle) srcHydrationStage(partition string, message *srcHydrationMes
 	}
 
 	return &preTransformationMessage{
-		partition:                       message.partition,
-		subJobs:                         message.subJobs,
-		archivalJobs:                    message.archivalJobs,
-		eventSchemaJobsBySourceId:       message.eventSchemaJobsBySourceId,
-		connectionDetailsMap:            message.connectionDetailsMap,
-		statusDetailsMap:                message.statusDetailsMap,
-		enricherStatusDetailsMap:        message.enricherStatusDetailsMap,
-		botManagementStatusDetailsMap:   message.botManagementStatusDetailsMap,
-		eventBlockingStatusDetailsMap:   message.eventBlockingStatusDetailsMap,
-		userSuppressionStatusDetailsMap: message.userSuppressionStatusDetailsMap,
-		dedupStatusDetailsMap:           message.dedupStatusDetailsMap,
-		gatewayIngestedStatusDetailsMap: message.gatewayIngestedStatusDetailsMap,
-		destFilterStatusDetailMap:       message.destFilterStatusDetailMap,
-		reportMetrics:                   message.reportMetrics,
-		totalEvents:                     message.totalEvents,
-		groupedEventsBySourceId:         message.groupedEventsBySourceId,
-		eventsByMessageID:               message.eventsByMessageID,
-		jobIDToSpecificDestMapOnly:      message.jobIDToSpecificDestMapOnly,
-		statusList:                      message.statusList,
-		jobList:                         message.jobList,
-		sourceDupStats:                  message.sourceDupStats,
-		dedupKeys:                       message.dedupKeys,
-		srcHydrationEnabledMap:          srcHydrationEnabledMap,
-		earlyDestinationFilter:          message.earlyDestinationFilter,
+		partition:                  message.partition,
+		subJobs:                    message.subJobs,
+		archivalJobs:               message.archivalJobs,
+		eventSchemaJobsBySourceId:  message.eventSchemaJobsBySourceId,
+		reportMetrics:              message.reportMetrics,
+		totalEvents:                message.totalEvents,
+		groupedEventsBySourceId:    message.groupedEventsBySourceId,
+		eventsByMessageID:          message.eventsByMessageID,
+		jobIDToSpecificDestMapOnly: message.jobIDToSpecificDestMapOnly,
+		statusList:                 message.statusList,
+		jobList:                    message.jobList,
+		sourceDupStats:             message.sourceDupStats,
+		dedupKeys:                  message.dedupKeys,
+		srcHydrationEnabledMap:     srcHydrationEnabledMap,
+		earlyDestinationFilter:     message.earlyDestinationFilter,
 	}, nil
 }
 

--- a/processor/src_hydration_stage_test.go
+++ b/processor/src_hydration_stage_test.go
@@ -792,7 +792,7 @@ func TestSrcHydrationStage(t *testing.T) {
 		// sorted by a stable key (PU + event name) rather than relying on append order/index.
 		expected := []*reportingtypes.PUReportedMetric{sentinel1, sentinel2, hydrationFailureRow}
 		metricKey := func(m *reportingtypes.PUReportedMetric) string {
-			return m.PUDetails.PU + "|" + m.StatusDetail.EventName
+			return m.PU + "|" + m.StatusDetail.EventName
 		}
 		sort.Slice(expected, func(i, j int) bool { return metricKey(expected[i]) < metricKey(expected[j]) })
 

--- a/processor/src_hydration_stage_test.go
+++ b/processor/src_hydration_stage_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"errors"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -671,6 +672,135 @@ func TestSrcHydrationStage(t *testing.T) {
 		require.Equal(t, ogEventSchemaJob.CustomVal, eventSchemaJobs[0].CustomVal)
 		require.Equal(t, ogEventSchemaJob.WorkspaceId, eventSchemaJobs[0].WorkspaceId)
 		require.Equal(t, jsonparser.GetStringOrEmpty(eventSchemaJobs[0].EventPayload, "productName"), "Test Product 1")
+	})
+
+	t.Run("hydration failure rows are appended to reportMetrics that arrive non-empty", func(t *testing.T) {
+		msgId := "message-1"
+		receivedAt := time.Now().In(time.UTC)
+		events := []types.TransformerEvent{
+			{
+				Message: map[string]any{
+					"type":      "track",
+					"event":     "Product Viewed",
+					"productId": "12345",
+				},
+				Metadata: types.Metadata{
+					MessageID:  msgId,
+					ReceivedAt: receivedAt.Format(misc.RFC3339Milli),
+					SourceID:   fblaSourceId,
+				},
+			},
+		}
+
+		// Setup mock transformer clients with error, forcing a hydration-failure row.
+		transformerClients := transformer.NewSimpleClients()
+		transformerClients.SetSrcHydrationOutput(types.SrcHydrationResponse{}, errors.New("hydration error"))
+
+		c := &testContext{}
+		c.Setup(t)
+		defer c.Finish()
+		conf := config.New()
+		proc := NewHandle(conf, transformerClients)
+		c.mockGatewayJobsDB.EXPECT().DeleteExecuting().AnyTimes()
+		Setup(proc, c, true, true, t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		err := proc.config.asyncInit.WaitContext(ctx)
+		require.NoError(t, err)
+
+		// Pre-seed reportMetrics with two sentinel rows, mimicking the eight-map assembly
+		// that now runs in preprocessStage and hands non-empty reportMetrics down to this
+		// stage (see assembleSideStatusDetailMetrics in processor.go).
+		sentinel1 := &reportingtypes.PUReportedMetric{
+			ConnectionDetails: reportingtypes.ConnectionDetails{SourceID: "sentinel-source-1"},
+			PUDetails: reportingtypes.PUDetails{
+				PU:        reportingtypes.GATEWAY,
+				InitialPU: true,
+			},
+			StatusDetail: &reportingtypes.StatusDetail{
+				Status:    "succeeded",
+				Count:     11,
+				EventName: "sentinel-event-1",
+				EventType: "track",
+			},
+		}
+		sentinel2 := &reportingtypes.PUReportedMetric{
+			ConnectionDetails: reportingtypes.ConnectionDetails{SourceID: "sentinel-source-2"},
+			PUDetails: reportingtypes.PUDetails{
+				PU: reportingtypes.DEDUP,
+			},
+			StatusDetail: &reportingtypes.StatusDetail{
+				Status:    "succeeded",
+				Count:     22,
+				EventName: "sentinel-event-2",
+				EventType: "track",
+			},
+		}
+
+		message := &srcHydrationMessage{
+			partition: "test-partition",
+			subJobs: subJob{
+				ctx: context.Background(),
+			},
+			eventSchemaJobsBySourceId: make(map[SourceIDT][]*jobsdb.JobT),
+			groupedEventsBySourceId: map[SourceIDT][]types.TransformerEvent{
+				SourceIDT(fblaSourceId): events,
+			},
+			eventsByMessageID:      make(map[string]types.SingularEventWithReceivedAt),
+			earlyDestinationFilter: true,
+			reportMetrics:          []*reportingtypes.PUReportedMetric{sentinel1, sentinel2},
+		}
+
+		// Execute the source hydration stage
+		result, err := proc.srcHydrationStage("test-partition", message)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		sampleEvent, err := jsonrs.Marshal(events[0].Message)
+		require.NoError(t, err)
+		hydrationFailureRow := &reportingtypes.PUReportedMetric{
+			ConnectionDetails: reportingtypes.ConnectionDetails{
+				SourceID:       fblaSourceId,
+				SourceCategory: "webhook",
+			},
+			PUDetails: reportingtypes.PUDetails{
+				InPU:       reportingtypes.DESTINATION_FILTER,
+				PU:         reportingtypes.SOURCE_HYDRATION,
+				TerminalPU: false,
+				InitialPU:  false,
+			},
+			StatusDetail: &reportingtypes.StatusDetail{
+				Status:         "aborted",
+				Count:          1,
+				StatusCode:     500,
+				SampleResponse: "hydration error",
+				SampleEvent:    sampleEvent,
+				EventName:      "Product Viewed",
+				EventType:      "track",
+				FailedMessages: []*reportingtypes.FailedMessage{
+					{
+						MessageID:  msgId,
+						ReceivedAt: receivedAt.Truncate(time.Millisecond),
+					},
+				},
+			},
+		}
+
+		// Assert the result contains both sentinels *and* the hydration row as a multiset,
+		// sorted by a stable key (PU + event name) rather than relying on append order/index.
+		expected := []*reportingtypes.PUReportedMetric{sentinel1, sentinel2, hydrationFailureRow}
+		metricKey := func(m *reportingtypes.PUReportedMetric) string {
+			return m.PUDetails.PU + "|" + m.StatusDetail.EventName
+		}
+		sort.Slice(expected, func(i, j int) bool { return metricKey(expected[i]) < metricKey(expected[j]) })
+
+		require.Len(t, result.reportMetrics, len(expected))
+		actual := append([]*reportingtypes.PUReportedMetric(nil), result.reportMetrics...)
+		sort.Slice(actual, func(i, j int) bool { return metricKey(actual[i]) < metricKey(actual[j]) })
+
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Test eventsByMessageID updated with hydrated data", func(t *testing.T) {


### PR DESCRIPTION
## What

Pure refactor, zero behavior change. Converts the eight side-PU status-details maps accumulated in the processor's preprocess loop (`statusDetailsMap`, `enricherStatusDetailsMap`, `botManagementStatusDetailsMap`, `eventBlockingStatusDetailsMap`, `userSuppressionStatusDetailsMap`, `dedupStatusDetailsMap`, `gatewayIngestedStatusDetailsMap`, `destFilterStatusDetailMap`) into `PUReportedMetric` rows at the end of `preprocessStage`, via a new `assembleSideStatusDetailMetrics` helper — instead of threading nine map fields (the eight maps + `connectionDetailsMap`) through `srcHydrationMessage` and `preTransformationMessage` and assembling them only at `pretransformStage`.

- The assembly loop body, the `AssertKeysSubset` guards, and the per-key row-emission order are relocated verbatim.
- The map fields are removed from `srcHydrationMessage` and `preTransformationMessage`; assembled rows ride the pre-existing `reportMetrics` field and the same `storeStage` transaction, behind the same `isReportingEnabled()` gate.
- Row content (ConnectionDetails, PUDetails, StatusDetail, counts) is unchanged. The only observable difference is slice ordering within `reportMetrics` (side-PU rows now precede source-hydration failure rows); `Report` inserts rows independently and no production code is position-sensitive. The one consumer of insertion order was the `srchydration` integration test, which sorted by `MIN(id)` — updated to sort by the report key instead (insertion order across PUs was never part of the contract; same-stage rows already depended on Go map iteration order).

## Why

Addresses the review discussion on #7325 ("why do we need to wait to reach the pretransform stage to fill reportMetrics for all these stages" / "it is weird having to carry over all these maps in the stage messages"). The maps are complete as soon as the preprocess loop finishes, so assembly can happen right there and the stage messages get 9 fields lighter.

## Tests

- New `TestAssembleSideStatusDetailMetrics`: table-driven map→PU pairing check (guards against silently swapping the same-typed positional map args), plus an all-eight-maps case asserting exactly one row per PU and per-row `ConnectionDetails` copies.
- New `TestSrcHydrationStage` subtest: hydration-failure rows are appended to a `reportMetrics` slice that now arrives non-empty (no clobbering/truncation), asserted as a multiset.
- Full `go test ./processor/...` and the `srchydration` integration test pass; the `reporting_dropped_events` integration test (which asserts real `reports`-table rows for `gateway`, `gw_ingested`, `dedup`, `destination_filter`) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrZn7jT7WtkTrujuMiU6d9
