### PR TITLE
fix(warehouse): pass temporary credentials to the clickhouse v2 s3 copy engine

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -533,6 +533,13 @@ func (ch *Clickhouse) UseS3CopyEngineForLoading() bool {
 	if !slices.Contains(ch.config.s3EngineEnabledWorkspaceIDs, ch.Warehouse.WorkspaceID) {
 		return false
 	}
+	// ObjectStorageType reports S3 for rudder storage, but that bucket is
+	// reached through the AWS SDK credential chain and the s3 table function
+	// only takes literal keys, which the destination config does not hold for
+	// it. Downloading the load files is the only path that can authenticate.
+	if ch.Uploader.UseRudderStorage() {
+		return false
+	}
 	return ch.ObjectStorage == warehouseutils.S3 || ch.ObjectStorage == warehouseutils.MINIO
 }
 

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -20,6 +20,7 @@ import (
 
 	clickhousestd "github.com/ClickHouse/clickhouse-go"
 	"github.com/google/uuid"
+	miniocredentials "github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -979,6 +980,12 @@ func testIntegration(t *testing.T, useV2 bool) {
 			disableNullable             bool
 			disableLoadTableStats       bool
 
+			// bucketProvider overrides the destination's provider, which is
+			// MINIO everywhere else in this table. S3 reaches the same bucket
+			// through the aws branch of credentials(), which mints short-lived
+			// credentials rather than reading the destination's own.
+			bucketProvider string
+
 			// commitEvery only changes behaviour on v2, which drives the commit
 			// cadence itself; v1 hands block_size to the driver and ignores it.
 			// The cases still run on both, which makes v1 the control: the same
@@ -1010,6 +1017,12 @@ func testIntegration(t *testing.T, useV2 bool) {
 				disableLoadTableStats:       false,
 			},
 			{
+				name:                        "using s3 engine with temporary credentials",
+				S3EngineEnabledWorkspaceIDs: []string{workspaceID},
+				fileName:                    "testdata/load-copy.csv.gz",
+				bucketProvider:              whutils.S3,
+			},
+			{
 				name:                  "normal loading using downloading of load files with disable load table stats",
 				fileName:              "testdata/load.csv.gz",
 				disableLoadTableStats: true,
@@ -1037,6 +1050,10 @@ func testIntegration(t *testing.T, useV2 bool) {
 
 		for i, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				if tc.bucketProvider == whutils.S3 && !useV2 {
+					t.Skip("v1 has no temporary credential path, and runs clickhouse 21, which predates the session token argument of the s3 table function")
+				}
+
 				conf := config.New()
 				conf.Set(configKey("s3EngineEnabledWorkspaceIDs"), tc.S3EngineEnabledWorkspaceIDs)
 				conf.Set(configKey("disableNullable"), tc.disableNullable)
@@ -1047,22 +1064,38 @@ func testIntegration(t *testing.T, useV2 bool) {
 
 				ch := newClickhouse(conf)
 
+				destConfig := map[string]any{
+					"bucketProvider":  whutils.MINIO,
+					"host":            host,
+					"port":            strconv.Itoa(clickhousePort),
+					"database":        database,
+					"user":            user,
+					"password":        password,
+					"bucketName":      bucketName,
+					"accessKeyID":     accessKeyID,
+					"secretAccessKey": secretAccessKey,
+					"endPoint":        minioEndpoint,
+				}
+				if tc.bucketProvider != "" {
+					destConfig["bucketProvider"] = tc.bucketProvider
+				}
+				if tc.bucketProvider == whutils.S3 {
+					chv2, ok := ch.(*clickhouse.ClickhouseV2)
+					require.True(t, ok)
+					// The server reaches AWS STS here. MinIO issues credentials
+					// of the same shape for its own users and validates the
+					// token on the way back in, so the fourth argument of the s3
+					// table function is covered without leaving the compose.
+					chv2.TemporaryS3Cred = func(*backendconfig.DestinationT) (string, string, string, error) {
+						return minioTemporaryCredentials(minioEndpoint, accessKeyID, secretAccessKey, region)
+					}
+				}
+
 				warehouse := model.Warehouse{
 					Namespace:   fmt.Sprintf("test_namespace_%d", i),
 					WorkspaceID: workspaceID,
 					Destination: backendconfig.DestinationT{
-						Config: map[string]any{
-							"bucketProvider":  whutils.MINIO,
-							"host":            host,
-							"port":            strconv.Itoa(clickhousePort),
-							"database":        database,
-							"user":            user,
-							"password":        password,
-							"bucketName":      bucketName,
-							"accessKeyID":     accessKeyID,
-							"secretAccessKey": secretAccessKey,
-							"endPoint":        minioEndpoint,
-						},
+						Config: destConfig,
 					},
 				}
 
@@ -2133,6 +2166,29 @@ func initializeClickhouseClusterMode(t *testing.T, clusterDBs []*sql.DB, tables 
 			}))
 		}
 	}
+}
+
+// minioTemporaryCredentials asks MinIO for short-lived credentials. MinIO
+// implements the AssumeRole call for any of its own users, root included, and
+// validates the session token it hands back on later S3 requests. The session
+// policy is spelled out rather than inherited so the credentials do not depend
+// on what the parent user happens to carry.
+func minioTemporaryCredentials(endpoint, accessKeyID, secretAccessKey, region string) (string, string, string, error) {
+	creds, err := miniocredentials.NewSTSAssumeRole("http://"+endpoint, miniocredentials.STSAssumeRoleOptions{
+		AccessKey:       accessKeyID,
+		SecretKey:       secretAccessKey,
+		Location:        region,
+		DurationSeconds: 3600,
+		Policy:          `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*","arn:aws:s3:::*/*"]}]}`,
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("creating sts credentials: %w", err)
+	}
+	value, err := creds.Get()
+	if err != nil {
+		return "", "", "", fmt.Errorf("retrieving sts credentials: %w", err)
+	}
+	return value.AccessKeyID, value.SecretAccessKey, value.SessionToken, nil
 }
 
 func newMockUploader(

--- a/warehouse/integrations/clickhouse/clickhousev2.go
+++ b/warehouse/integrations/clickhouse/clickhousev2.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -41,6 +42,11 @@ type ClickhouseV2 struct {
 	Uploader           warehouseutils.Uploader
 	connectTimeout     time.Duration
 	LoadFileDownloader downloader.Downloader
+
+	// TemporaryS3Cred mints the short-lived credentials the copy engine hands
+	// to the s3 table function. NewV2 points it at the shared helper, which
+	// reaches AWS; a test can point it somewhere closer.
+	TemporaryS3Cred func(*backendconfig.DestinationT) (string, string, string, error)
 
 	conf   *config.Config
 	logger logger.Logger
@@ -67,6 +73,7 @@ func NewV2(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse
 	ch.conf = conf
 	ch.logger = log.Child("integrations").Child("clickhouse").Child("v2")
 	ch.stats = stat
+	ch.TemporaryS3Cred = warehouseutils.GetTemporaryS3Cred
 
 	ch.config.queryDebugLogs = conf.GetBoolVar(false, "Warehouse.clickhouse.v2.queryDebugLogs")
 	// commitEvery is the number of rows between commits, which is what bounds

--- a/warehouse/integrations/clickhouse/driver_v2.go
+++ b/warehouse/integrations/clickhouse/driver_v2.go
@@ -18,14 +18,14 @@ import (
 // unknownDatabase is ClickHouse's UNKNOWN_DATABASE error code.
 const unknownDatabase = 81
 
-// s3CredentialsRegex masks the access key and secret that loadByCopyCommand
-// passes to the s3 table function. Without it the middleware logs the statement
-// verbatim once it crosses the slow query threshold, which a full table copy
-// does routinely. The credentials are positional single-quoted arguments rather
-// than named ones, so the pattern anchors on s3( and the location that precedes
-// them.
+// s3CredentialsRegex masks the credentials that loadByCopyCommand passes to
+// the s3 table function. Without it the middleware logs the statement verbatim
+// once it crosses the slow query threshold, which a full table copy does
+// routinely. They are positional single-quoted arguments rather than named
+// ones, and there are two of them or three when a session token is included,
+// so the pattern collapses everything between the location and the format.
 var s3CredentialsRegex = map[string]string{
-	`(s3\(\s*'[^']*',\s*)'[^']*',\s*'[^']*'`: `${1}'***', '***'`,
+	`(s3\(\s*'[^']*',\s*)(?:'[^']*',\s*)+('CSV')`: `${1}'***', ${2}`,
 }
 
 // connect opens a connection and wraps it in the shared middleware.

--- a/warehouse/integrations/clickhouse/driver_v2_test.go
+++ b/warehouse/integrations/clickhouse/driver_v2_test.go
@@ -1,7 +1,6 @@
 package clickhouse
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,68 +9,96 @@ import (
 )
 
 // TestS3CredentialsRegexV2 guards the masking the middleware applies before it
-// logs a query. The statement below mirrors the one loadByCopyCommand builds:
-// if that template changes shape, this is what catches the credentials going
-// back into the logs.
+// logs a query. It builds the statement through copySQLStatement, so a change
+// to the shape of the copy command is a change to what is under test here.
 func TestS3CredentialsRegexV2(t *testing.T) {
 	const (
 		accessKeyID     = "AKIAIOSFODNN7EXAMPLE"
 		secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		sessionToken    = "FQoGZXIvYXdzEPP//////////wEaDEXAMPLESESSIONTOKEN"
 		loadFolder      = "s3://bucket/rudder/uploads/*.csv.gz"
 		columnTypes     = "id String,received_at DateTime"
 	)
 
-	statement := fmt.Sprintf(`
-		INSERT INTO %[1]q.%[2]q (
-			%[3]s
+	statementWith := func(token string) string {
+		return copySQLStatement("namespace", "table", "id,received_at",
+			s3TableFunctionArgs(loadFolder, accessKeyID, secretAccessKey, token, columnTypes),
 		)
-		SELECT
-		  *
-		FROM
-		  s3(
-			'%[4]s',
-		  	'%[5]s',
-		  	'%[6]s',
-			'CSV',
-			'%[7]s',
-			'gz'
-		  )
-			settings
-				date_time_input_format = 'best_effort',
-				input_format_csv_arrays_as_nested_csv = 1;
-		`,
-		"namespace",      // 1
-		"table",          // 2
-		"id,received_at", // 3
-		loadFolder,       // 4
-		accessKeyID,      // 5
-		secretAccessKey,  // 6
-		columnTypes,      // 7
-	)
+	}
 
-	masked, err := misc.ReplaceMultiRegex(statement, s3CredentialsRegex)
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{name: "static keys", token: ""},
+		{name: "temporary credentials", token: sessionToken},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			statement := statementWith(tc.token)
 
-	require.NotContains(t, masked, accessKeyID)
-	require.NotContains(t, masked, secretAccessKey)
-	require.Contains(t, masked, "'***', '***'")
+			masked, err := misc.ReplaceMultiRegex(statement, s3CredentialsRegex)
+			require.NoError(t, err)
 
-	// The rest of the statement has to survive, or the log stops being useful.
-	require.Contains(t, masked, loadFolder)
-	require.Contains(t, masked, columnTypes)
-	require.Contains(t, masked, "'CSV'")
-	require.Contains(t, masked, "date_time_input_format = 'best_effort'")
+			require.NotContains(t, masked, accessKeyID)
+			require.NotContains(t, masked, secretAccessKey)
+			if tc.token != "" {
+				require.Contains(t, statement, sessionToken, "the token has to reach the statement to be worth masking")
+				require.NotContains(t, masked, sessionToken)
+			}
+			require.Contains(t, masked, "'***'")
 
-	t.Run("masking twice changes nothing", func(t *testing.T) {
-		twice, err := misc.ReplaceMultiRegex(masked, s3CredentialsRegex)
-		require.NoError(t, err)
-		require.Equal(t, masked, twice)
-	})
+			// The rest of the statement has to survive, or the log stops being
+			// useful.
+			require.Contains(t, masked, loadFolder)
+			require.Contains(t, masked, columnTypes)
+			require.Contains(t, masked, "'CSV'")
+			require.Contains(t, masked, "date_time_input_format = 'best_effort'")
+
+			t.Run("masking twice changes nothing", func(t *testing.T) {
+				twice, err := misc.ReplaceMultiRegex(masked, s3CredentialsRegex)
+				require.NoError(t, err)
+				require.Equal(t, masked, twice)
+			})
+		})
+	}
 
 	t.Run("statements without s3 are untouched", func(t *testing.T) {
 		insert := `INSERT INTO "namespace"."table" ("id","received_at") VALUES (?,?)`
 		out, err := misc.ReplaceMultiRegex(insert, s3CredentialsRegex)
 		require.NoError(t, err)
 		require.Equal(t, insert, out)
+	})
+}
+
+// TestS3TableFunctionArgsV2 pins the positions, which is the whole contract:
+// the s3 table function reads its arguments by index, so an extra one in the
+// wrong place is read as a format or a structure rather than rejected.
+func TestS3TableFunctionArgsV2(t *testing.T) {
+	const (
+		loadFolder  = "s3://bucket/rudder/uploads/*.csv.gz"
+		columnTypes = "id String,received_at DateTime"
+	)
+
+	t.Run("without a session token", func(t *testing.T) {
+		require.Equal(t, []string{
+			"'" + loadFolder + "'",
+			"'key'",
+			"'secret'",
+			"'CSV'",
+			"'" + columnTypes + "'",
+			"'gz'",
+		}, s3TableFunctionArgs(loadFolder, "key", "secret", "", columnTypes))
+	})
+
+	t.Run("with a session token", func(t *testing.T) {
+		require.Equal(t, []string{
+			"'" + loadFolder + "'",
+			"'key'",
+			"'secret'",
+			"'token'",
+			"'CSV'",
+			"'" + columnTypes + "'",
+			"'gz'",
+		}, s3TableFunctionArgs(loadFolder, "key", "secret", "token", columnTypes))
 	})
 }

--- a/warehouse/integrations/clickhouse/load_v2.go
+++ b/warehouse/integrations/clickhouse/load_v2.go
@@ -27,6 +27,7 @@ import (
 var (
 	errObjectStorageNotSupported = errors.New("objectStorage not supported for loading using S3 engine")
 	errCSVColumnsMismatch        = errors.New("csv columns mismatch")
+	errMissingS3Credentials      = errors.New("no object storage credentials for the s3 engine")
 )
 
 func (ch *ClickhouseV2) LoadTable(ctx context.Context, tableName string) (*types.LoadTableStats, error) {
@@ -140,37 +141,14 @@ func (ch *ClickhouseV2) loadByCopyCommand(ctx context.Context, tableName string,
 	loadFolderDir, _ := path.Split(csvObjectLocation)
 	loadFolder := loadFolderDir + "*.csv.gz"
 
-	accessKeyID, secretAccessKey, err := ch.credentials()
+	accessKeyID, secretAccessKey, sessionToken, err := ch.credentials()
 	if err != nil {
 		return fmt.Errorf("getting auth credentials: %w", err)
 	}
 
-	sqlStatement := fmt.Sprintf(`
-		INSERT INTO %[1]q.%[2]q (
-			%[3]s
-		)
-		SELECT
-		  *
-		FROM
-		  s3(
-			'%[4]s',
-		  	'%[5]s',
-		  	'%[6]s',
-			'CSV',
-			'%[7]s',
-			'gz'
-		  )
-			settings
-				date_time_input_format = 'best_effort',
-				input_format_csv_arrays_as_nested_csv = 1;
-		`,
-		ch.Namespace,                   // 1
-		tableName,                      // 2
-		sortedColumnNames,              // 3
-		loadFolder,                     // 4
-		accessKeyID,                    // 5
-		secretAccessKey,                // 6
-		sortedColumnNamesWithDataTypes, // 7
+	sqlStatement := copySQLStatement(
+		ch.Namespace, tableName, sortedColumnNames,
+		s3TableFunctionArgs(loadFolder, accessKeyID, secretAccessKey, sessionToken, sortedColumnNamesWithDataTypes),
 	)
 	_, err = ch.DB.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -179,6 +157,49 @@ func (ch *ClickhouseV2) loadByCopyCommand(ctx context.Context, tableName string,
 
 	log.Infon("Completed load by copy command")
 	return nil
+}
+
+// s3TableFunctionArgs returns the positional arguments the s3 table function
+// reads a folder of gzipped CSV with. The session token sits between the secret
+// and the format, and servers older than 24.1 do not know about it at all, so it
+// is left out entirely when there is none: a destination with static keys sends
+// exactly what it always sent.
+func s3TableFunctionArgs(loadFolder, accessKeyID, secretAccessKey, sessionToken, columnTypes string) []string {
+	args := []string{
+		fmt.Sprintf("'%s'", loadFolder),
+		fmt.Sprintf("'%s'", accessKeyID),
+		fmt.Sprintf("'%s'", secretAccessKey),
+	}
+	if sessionToken != "" {
+		args = append(args, fmt.Sprintf("'%s'", sessionToken))
+	}
+	return append(args,
+		"'CSV'",
+		fmt.Sprintf("'%s'", columnTypes),
+		"'gz'",
+	)
+}
+
+// copySQLStatement is the statement the copy engine runs. It is separate so the
+// masking test can build the real thing rather than a copy of it that drifts.
+func copySQLStatement(namespace, tableName, sortedColumnNames string, s3Args []string) string {
+	return fmt.Sprintf(`
+		INSERT INTO %[1]q.%[2]q (
+			%[3]s
+		)
+		SELECT
+		  *
+		FROM
+		  s3(%[4]s)
+			settings
+				date_time_input_format = 'best_effort',
+				input_format_csv_arrays_as_nested_csv = 1;
+		`,
+		namespace,                  // 1
+		tableName,                  // 2
+		sortedColumnNames,          // 3
+		strings.Join(s3Args, ", "), // 4
+	)
 }
 
 func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) error {
@@ -208,14 +229,36 @@ func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableNam
 	return nil
 }
 
-func (ch *ClickhouseV2) credentials() (accessKeyID, secretAccessKey string, err error) {
-	if ch.ObjectStorage == warehouseutils.S3 {
-		return ch.Warehouse.GetStringDestinationConfig(ch.conf, model.AWSAccessSecretSetting), ch.Warehouse.GetStringDestinationConfig(ch.conf, model.AWSAccessKeySetting), nil
+// credentials returns the literals the s3 table function authenticates with.
+// A session token comes back for aws, where they are always short-lived, and
+// never for minio.
+func (ch *ClickhouseV2) credentials() (accessKeyID, secretAccessKey, sessionToken string, err error) {
+	switch ch.ObjectStorage {
+	case warehouseutils.S3:
+		// An aws destination need not hold keys at all: rudder storage, a role
+		// and the shared copy user all authenticate through the SDK credential
+		// chain, and the s3 table function cannot, because it takes literals.
+		// So mint them, without asking which shape the destination is — the
+		// same thing redshift, snowflake and deltalake do for their own copy
+		// statements, and GetTemporaryS3Cred covers every shape including plain
+		// static keys.
+		accessKeyID, secretAccessKey, sessionToken, err = ch.TemporaryS3Cred(&ch.Warehouse.Destination)
+		if err != nil {
+			return "", "", "", fmt.Errorf("getting temporary s3 credentials: %w", err)
+		}
+	case warehouseutils.MINIO:
+		accessKeyID = ch.Warehouse.GetStringDestinationConfig(ch.conf, model.MinioAccessKeyIDSetting)
+		secretAccessKey = ch.Warehouse.GetStringDestinationConfig(ch.conf, model.MinioSecretAccessKeySetting)
+	default:
+		return "", "", "", errObjectStorageNotSupported
 	}
-	if ch.ObjectStorage == warehouseutils.MINIO {
-		return ch.Warehouse.GetStringDestinationConfig(ch.conf, model.MinioAccessKeyIDSetting), ch.Warehouse.GetStringDestinationConfig(ch.conf, model.MinioSecretAccessKeySetting), nil
+	// Empty keys would be interpolated into the statement as '' and come back
+	// as an access error from the server, which says nothing about where the
+	// keys were meant to come from.
+	if accessKeyID == "" || secretAccessKey == "" {
+		return "", "", "", errMissingS3Credentials
 	}
-	return "", "", errObjectStorageNotSupported
+	return accessKeyID, secretAccessKey, sessionToken, nil
 }
 
 func (ch *ClickhouseV2) TestLoadTable(ctx context.Context, _, tableName string, payloadMap map[string]any, _ string) error {

--- a/warehouse/integrations/clickhouse/load_v2_test.go
+++ b/warehouse/integrations/clickhouse/load_v2_test.go
@@ -1,0 +1,130 @@
+package clickhouse
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+// TestCredentialsV2 covers where the copy engine's literals come from. The s3
+// table function only takes literals, and an aws destination need not hold any
+// — rudder storage, a role and the shared copy user all authenticate through
+// the SDK credential chain — so aws always goes through GetTemporaryS3Cred and
+// minio never does.
+func TestCredentialsV2(t *testing.T) {
+	errMinting := errors.New("sts unreachable")
+
+	newCH := func(objectStorage string, destConfig map[string]any) *ClickhouseV2 {
+		ch := NewV2(config.New(), logger.NOP, stats.NOP)
+		ch.ObjectStorage = objectStorage
+		ch.Warehouse = model.Warehouse{
+			Destination: backendconfig.DestinationT{Config: destConfig},
+		}
+		ch.TemporaryS3Cred = func(*backendconfig.DestinationT) (string, string, string, error) {
+			return "tempKey", "tempSecret", "tempToken", nil
+		}
+		return ch
+	}
+
+	// The destination shapes below all reach the same call. They are listed
+	// separately because each one used to take a different path, and the point
+	// of the change is that none of them does any more.
+	for _, tc := range []struct {
+		name       string
+		destConfig map[string]any
+	}{
+		{
+			name: "rudder storage",
+			destConfig: map[string]any{
+				"useRudderStorage": true,
+			},
+		},
+		{
+			name: "a role",
+			destConfig: map[string]any{
+				"iamRoleARN": "arn:aws:iam::000000000000:role/rudder",
+			},
+		},
+		{
+			// Neither keys nor a role: the shared copy user, whose credentials
+			// live in the server's env rather than the destination.
+			name:       "no credentials at all",
+			destConfig: map[string]any{},
+		},
+		{
+			// Static keys are minted from too, so the statement carries a token
+			// that expires rather than the customer's long-term secret.
+			name: "static keys",
+			destConfig: map[string]any{
+				"accessKeyID": "staticKey",
+				"accessKey":   "staticSecret",
+			},
+		},
+	} {
+		t.Run("s3 with "+tc.name, func(t *testing.T) {
+			ch := newCH(warehouseutils.S3, tc.destConfig)
+
+			accessKeyID, secretAccessKey, sessionToken, err := ch.credentials()
+			require.NoError(t, err)
+			require.Equal(t, "tempKey", accessKeyID)
+			require.Equal(t, "tempSecret", secretAccessKey)
+			require.Equal(t, "tempToken", sessionToken)
+		})
+	}
+
+	t.Run("minting failure is reported", func(t *testing.T) {
+		ch := newCH(warehouseutils.S3, map[string]any{})
+		ch.TemporaryS3Cred = func(*backendconfig.DestinationT) (string, string, string, error) {
+			return "", "", "", errMinting
+		}
+
+		_, _, _, err := ch.credentials()
+		require.ErrorIs(t, err, errMinting)
+	})
+
+	t.Run("minted credentials that came back empty are named", func(t *testing.T) {
+		ch := newCH(warehouseutils.S3, map[string]any{})
+		ch.TemporaryS3Cred = func(*backendconfig.DestinationT) (string, string, string, error) {
+			return "", "", "", nil
+		}
+
+		_, _, _, err := ch.credentials()
+		require.ErrorIs(t, err, errMissingS3Credentials)
+	})
+
+	t.Run("minio reads its own keys and gets no token", func(t *testing.T) {
+		ch := newCH(warehouseutils.MINIO, map[string]any{
+			"accessKeyID":     "minioKey",
+			"secretAccessKey": "minioSecret",
+		})
+
+		accessKeyID, secretAccessKey, sessionToken, err := ch.credentials()
+		require.NoError(t, err)
+		require.Equal(t, "minioKey", accessKeyID)
+		require.Equal(t, "minioSecret", secretAccessKey)
+		require.Empty(t, sessionToken, "minio has no STS to mint from")
+	})
+
+	t.Run("missing minio keys are named rather than interpolated", func(t *testing.T) {
+		ch := newCH(warehouseutils.MINIO, map[string]any{"accessKeyID": "minioKey"})
+
+		_, _, _, err := ch.credentials()
+		require.ErrorIs(t, err, errMissingS3Credentials)
+	})
+
+	t.Run("unsupported object storage", func(t *testing.T) {
+		ch := newCH(warehouseutils.GCS, map[string]any{})
+
+		_, _, _, err := ch.credentials()
+		require.ErrorIs(t, err, errObjectStorageNotSupported)
+	})
+}


### PR DESCRIPTION
ObjectStorageType reports S3 whenever useRudderStorage is set, so
UseS3CopyEngineForLoading engaged and credentials() then read accessKeyID
and accessKey off the destination config — which describes the customer's
bucket, not Rudder's. They came back empty and were interpolated into the s3
table function as '', which the server rejects as an access error that says
nothing about where the keys should have come from.

Rudder storage is not the only destination that holds no keys. A role-based
one carries an iamRoleARN instead, and one with neither falls back to the
shared copy user whose credentials live in the server's env — see
GetObjectStorageConfig. All three authenticate through the AWS SDK credential
chain, which the s3 table function cannot use because it only takes literals.

So mint the literals instead of enumerating which shape the destination is.
whutils.GetTemporaryS3Cred already covers every one of them, including plain
static keys, and redshift, snowflake and deltalake all build their copy
credentials from it unconditionally for exactly this reason. ClickHouse can
too: the s3 table function has taken a session token as its fourth positional
argument since 24.1, so the copy engine stays available to every aws
destination rather than falling back to downloading each load file. A static
key destination now sends a credential that expires rather than the
customer's long-term secret, which is the same trade the other three make.

minio keeps reading its own keys: it has no STS to mint from. The token is
omitted from the statement when there is none, so that path sends the six
arguments it always sent. v1 keeps skipping the engine for rudder storage
instead: it has no temporary credential path, and runs against clickhouse 21,
which predates the argument entirely.

credentials() also errors on empty keys rather than interpolating them, so a
misconfigured destination fails with a message that names the cause, and the
query-log mask widens to cover a third credential argument.

The load round trip gains a case that reaches the same minio bucket as an aws
destination, minting from minio's own STS so the session token the statement
carries is one the bucket actually validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pXCMMrSLnt63xCWqvXhQ4