### PR TITLE
fix(warehouse): retire idle clickhouse v2 connections

### DIFF
--- a/warehouse/integrations/clickhouse/clickhousev2.go
+++ b/warehouse/integrations/clickhouse/clickhousev2.go
@@ -50,6 +50,8 @@ type ClickhouseV2 struct {
 		queryDebugLogs              bool
 		commitEvery                 int
 		poolSize                    int
+		connMaxIdleTime             time.Duration
+		connMaxLifetime             time.Duration
 		readTimeout                 time.Duration
 		compress                    bool
 		disableNullable             bool
@@ -77,6 +79,11 @@ func NewV2(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse
 	// out, and keeping the floor there leaves small values usable in tests.
 	ch.config.commitEvery = max(conf.GetIntVar(1000000, 1, "Warehouse.clickhouse.v2.commitEvery"), 1)
 	ch.config.poolSize = conf.GetIntVar(100, 1, "Warehouse.clickhouse.v2.poolSize")
+	// Every block takes a connection out of the pool, so a connection the
+	// server closed while it sat idle has to be retired before a block picks
+	// it up.
+	ch.config.connMaxIdleTime = conf.GetDurationVar(5, time.Minute, "Warehouse.clickhouse.v2.connMaxIdleTime")
+	ch.config.connMaxLifetime = conf.GetDurationVar(30, time.Minute, "Warehouse.clickhouse.v2.connMaxLifetime")
 	ch.config.readTimeout = conf.GetDurationVar(300, time.Second, "Warehouse.clickhouse.v2.readTimeout")
 	ch.config.compress = conf.GetBoolVar(false, "Warehouse.clickhouse.v2.compress")
 	ch.config.disableNullable = conf.GetBoolVar(false, "Warehouse.clickhouse.v2.disableNullable")

--- a/warehouse/integrations/clickhouse/driver_v2.go
+++ b/warehouse/integrations/clickhouse/driver_v2.go
@@ -62,6 +62,13 @@ func (ch *ClickhouseV2) connect(includeDatabase bool) (*sqlmw.DB, error) {
 	db := clickhouse.OpenDB(opts)
 	db.SetMaxOpenConns(ch.config.poolSize)
 	db.SetMaxIdleConns(ch.config.poolSize)
+	// A load commits one block per transaction, so every block takes a
+	// connection from the pool. Without a lifetime, a connection the server
+	// closed while it sat idle stays in the pool and the first write on it
+	// fails as driver: bad connection — which database/sql cannot retry once
+	// the connection is bound to a transaction.
+	db.SetConnMaxIdleTime(ch.config.connMaxIdleTime)
+	db.SetConnMaxLifetime(ch.config.connMaxLifetime)
 
 	return sqlmw.New(
 		db,


### PR DESCRIPTION
# Description

A v2 load commits one block per transaction, so every block takes a connection out of the pool. The pool had a size but no lifetime, so a connection the server closed while it sat idle stayed in it.

### Why it surfaces as a load failure

`BeginTx` only health-checks the connection — a cheap local check that passes. `prepareBatch` then does the first real I/O on that dead socket and fails. The driver turns it into `driver.ErrBadConn`, and because the connection is already bound to a transaction, `database/sql` cannot swap it out the way it does for `db.Query`, `db.Exec` and `db.Begin`. The error reaches the caller as:

```
preparing statement INSERT INTO ...: driver: bad connection
```

That fails the whole table load, however many blocks had already landed. Seen in production after 6,275,000 rows.

### The fix

`SetConnMaxIdleTime` and `SetConnMaxLifetime` on the v2 pool, so a stale connection is retired before a block picks it up.

| key | default |
| --- | --- |
| `Warehouse.clickhouse.v2.connMaxIdleTime` | `5m` |
| `Warehouse.clickhouse.v2.connMaxLifetime` | `30m` |

### Scope

14 lines across `clickhousev2.go` and `driver_v2.go`. v1 is untouched. No behaviour change beyond connection recycling.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-7100/crew-workspace-loading-is-taking-lot-of-time
https://linear.app/rudderstack/issue/INT-7107/investigate-connection-time-out

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
