### PR TITLE
fix(warehouse): retry a failed clickhouse v2 block

### DIFF
--- a/warehouse/integrations/clickhouse/clickhousev2.go
+++ b/warehouse/integrations/clickhouse/clickhousev2.go
@@ -49,6 +49,7 @@ type ClickhouseV2 struct {
 	config struct {
 		queryDebugLogs              bool
 		commitEvery                 int
+		maxRetriesPerBlock          int
 		poolSize                    int
 		connMaxIdleTime             time.Duration
 		connMaxLifetime             time.Duration
@@ -78,6 +79,10 @@ func NewV2(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse
 	// load spins forever committing empty batches. One is enough to rule that
 	// out, and keeping the floor there leaves small values usable in tests.
 	ch.config.commitEvery = max(conf.GetIntVar(1000000, 1, "Warehouse.clickhouse.v2.commitEvery"), 1)
+	// The number of times one block may be sent again, not a count of blocked
+	// retries: a block that failed on a connection the pool handed over dead is
+	// worth repeating, anything the server rejected is not. Zero disables them.
+	ch.config.maxRetriesPerBlock = conf.GetIntVar(3, 1, "Warehouse.clickhouse.v2.maxRetriesPerBlock")
 	ch.config.poolSize = conf.GetIntVar(100, 1, "Warehouse.clickhouse.v2.poolSize")
 	// Every block takes a connection out of the pool, so a connection the
 	// server closed while it sat idle has to be retired before a block picks

--- a/warehouse/integrations/clickhouse/load_v2.go
+++ b/warehouse/integrations/clickhouse/load_v2.go
@@ -4,18 +4,25 @@ import (
 	"compress/gzip"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/csv"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path"
 	"slices"
 	"sort"
 	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 
+	"github.com/rudderlabs/rudder-server/utils/backoffvoid"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
@@ -346,9 +353,7 @@ func (ch *ClickhouseV2) loadTableFromFiles(
 //
 // A return below commitEvery means EOF was reached, which is how the caller
 // knows to stop. When the row count is an exact multiple of commitEvery the
-// caller makes one more call that reads EOF and commits nothing: that costs a
-// prepare and a query close but no data frame, since batch.Send skips the send
-// entirely for a zero-row block.
+// caller makes one more call that reads EOF and sends nothing.
 //
 // "Transaction" is the driver's word, not ClickHouse's: BeginTx sends nothing
 // and only health-checks the connection, Commit is batch.Send, and Rollback
@@ -363,9 +368,86 @@ func (ch *ClickhouseV2) insertBlock(
 	columnKeys []string,
 	schema model.TableSchema,
 ) (int, error) {
-	var inserted int
+	block, err := readBlock(csvReader, columnKeys, ch.config.commitEvery)
+	if err != nil {
+		return 0, err
+	}
+	if len(block) == 0 {
+		return 0, nil
+	}
 
-	err := ch.DB.WithTx(ctx, func(txCtx context.Context, txn *sqlmw.Tx) error {
+	if err := ch.withBlockRetries(ctx, func() error {
+		return ch.sendBlock(ctx, insertSQL, block, columnKeys, schema)
+	}); err != nil {
+		return 0, err
+	}
+	return len(block), nil
+}
+
+// withBlockRetries runs send under the retry policy for one block: a failure
+// that came from the connection is repeated, anything the server rejected is
+// not, and the whole thing is bounded by maxRetriesPerBlock. send always runs
+// at least once.
+//
+// It is separate from insertBlock so the policy can be exercised without a
+// server, and so a caller can override or extend the options — the later of two
+// conflicting options wins, which is what lets a test collapse the delay.
+func (ch *ClickhouseV2) withBlockRetries(ctx context.Context, send func() error, opts ...backoff.RetryOption) error {
+	return backoffvoid.Retry(ctx, func() error {
+		err := send()
+		if err == nil {
+			return nil
+		}
+		if !isRetryableSendError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, append([]backoff.RetryOption{
+		backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
+		backoff.WithMaxElapsedTime(0),
+		backoff.WithMaxTries(uint(ch.config.maxRetriesPerBlock) + 1),
+	}, opts...)...)
+}
+
+// readBlock reads up to size rows off csvReader.
+//
+// The rows are held rather than bound and sent as they are read, because the
+// reader has already moved past them: a send that has to be repeated has to
+// repeat these rows, not pull the next ones. Retrying without this would skip a
+// block's worth of data and report success. The cost is the block's raw text
+// staying in memory until it lands, which makes commitEvery a memory knob on
+// top of a batching one.
+func readBlock(csvReader *csv.Reader, columnKeys []string, size int) ([][]string, error) {
+	block := make([][]string, 0, size)
+	for len(block) < size {
+		record, err := csvReader.Read()
+		if errors.Is(err, io.EOF) {
+			return block, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading csv: %w", err)
+		}
+		if len(columnKeys) != len(record) {
+			return nil, fmt.Errorf("%w: columns in row: %d, columns in upload schema: %d",
+				errCSVColumnsMismatch, len(record), len(columnKeys),
+			)
+		}
+		block = append(block, record)
+	}
+	return block, nil
+}
+
+// sendBlock binds every row and commits the batch. Binding happens here rather
+// than in readBlock so a retry rebinds from the raw text, which keeps the held
+// block as small as it can be.
+func (ch *ClickhouseV2) sendBlock(
+	ctx context.Context,
+	insertSQL string,
+	block [][]string,
+	columnKeys []string,
+	schema model.TableSchema,
+) error {
+	return ch.DB.WithTx(ctx, func(txCtx context.Context, txn *sqlmw.Tx) error {
 		// A *sql.Stmt belongs to its transaction, and sending a batch is what
 		// ends one, so every block prepares the same SQL again on a fresh
 		// transaction.
@@ -379,20 +461,7 @@ func (ch *ClickhouseV2) insertBlock(
 		}
 		defer func() { _ = stmt.Close() }()
 
-		for inserted < ch.config.commitEvery {
-			record, err := csvReader.Read()
-			if errors.Is(err, io.EOF) {
-				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("reading csv: %w", err)
-			}
-			if len(columnKeys) != len(record) {
-				return fmt.Errorf("%w: columns in row: %d, columns in upload schema: %d",
-					errCSVColumnsMismatch, len(record), len(columnKeys),
-				)
-			}
-
+		for _, record := range block {
 			values := make([]any, 0, len(record))
 			for index, value := range record {
 				values = append(values, ch.bindValue(value, schema[columnKeys[index]]))
@@ -400,9 +469,25 @@ func (ch *ClickhouseV2) insertBlock(
 			if _, err := stmt.ExecContext(txCtx, values...); err != nil {
 				return fmt.Errorf("executing statement: %w", err)
 			}
-			inserted++
 		}
 		return nil
 	})
-	return inserted, err
+}
+
+// isRetryableSendError reports whether a failed block send is worth repeating.
+//
+// Only connection-level failures are: the pool can hand over a socket the
+// server closed while it sat idle, and the first write on it fails. Inside a
+// transaction database/sql cannot swap that connection out itself, so the error
+// reaches us as driver.ErrBadConn. Anything the server actually rejected is
+// deterministic and would fail the same way again.
+func isRetryableSendError(err error) bool {
+	if errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
 }

--- a/warehouse/integrations/clickhouse/retry_v2_test.go
+++ b/warehouse/integrations/clickhouse/retry_v2_test.go
@@ -1,0 +1,121 @@
+package clickhouse
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+)
+
+// TestWithBlockRetriesV2 covers which failures buy another attempt and how many
+// there are. Getting this wrong is expensive in both directions: too eager and a
+// block the server rejected is sent again and again, too shy and one dead socket
+// out of the pool fails a load that had already inserted millions of rows.
+func TestWithBlockRetriesV2(t *testing.T) {
+	// The real policy waits a second between attempts. Options are applied in
+	// order and the last of a kind wins, so passing a shorter backoff replaces
+	// it without touching what is under test.
+	fast := backoff.WithBackOff(backoff.NewConstantBackOff(time.Millisecond))
+
+	newCH := func(maxRetriesPerBlock int) *ClickhouseV2 {
+		conf := config.New()
+		conf.Set("Warehouse.clickhouse.v2.maxRetriesPerBlock", maxRetriesPerBlock)
+		return NewV2(conf, logger.NOP, stats.NOP)
+	}
+
+	// failThenSucceed returns a send that fails with err its first n times.
+	failThenSucceed := func(n int, err error, attempts *int) func() error {
+		return func() error {
+			*attempts++
+			if *attempts <= n {
+				return err
+			}
+			return nil
+		}
+	}
+
+	t.Run("a send that works is attempted once", func(t *testing.T) {
+		var attempts int
+		require.NoError(t, newCH(3).withBlockRetries(context.Background(), failThenSucceed(0, nil, &attempts), fast))
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("a connection failure is repeated until it lands", func(t *testing.T) {
+		var attempts int
+		err := newCH(3).withBlockRetries(context.Background(),
+			failThenSucceed(2, driver.ErrBadConn, &attempts), fast)
+		require.NoError(t, err)
+		require.Equal(t, 3, attempts, "two failures then the send that worked")
+	})
+
+	t.Run("a rejected block is not repeated", func(t *testing.T) {
+		// What the server says no to it will say no to again. Sending it once
+		// more only widens the window for a partially loaded table.
+		rejected := errors.New("code: 62, DB::Exception: Syntax error")
+
+		var attempts int
+		err := newCH(3).withBlockRetries(context.Background(),
+			failThenSucceed(99, rejected, &attempts), fast)
+		require.ErrorIs(t, err, rejected)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("the budget is finite and the last failure is returned", func(t *testing.T) {
+		var attempts int
+		err := newCH(3).withBlockRetries(context.Background(),
+			failThenSucceed(99, driver.ErrBadConn, &attempts), fast)
+		require.ErrorIs(t, err, driver.ErrBadConn)
+		require.Equal(t, 4, attempts, "the first send plus maxRetriesPerBlock")
+	})
+
+	t.Run("zero retries still sends once", func(t *testing.T) {
+		var attempts int
+		err := newCH(0).withBlockRetries(context.Background(),
+			failThenSucceed(99, driver.ErrBadConn, &attempts), fast)
+		require.ErrorIs(t, err, driver.ErrBadConn)
+		require.Equal(t, 1, attempts)
+	})
+
+	// The driver hands these back wrapped, so the classifier has to unwrap
+	// rather than compare. A miss here turns every transient failure into a
+	// failed load, which is the bug this whole change exists to remove.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "bad connection", err: driver.ErrBadConn},
+		{name: "broken pipe", err: syscall.EPIPE},
+		{name: "connection reset", err: syscall.ECONNRESET},
+		{name: "a net.OpError", err: &net.OpError{Op: "write", Err: syscall.ECONNRESET}},
+	} {
+		t.Run("wrapped "+tc.name+" is still retried", func(t *testing.T) {
+			var attempts int
+			err := newCH(2).withBlockRetries(context.Background(),
+				failThenSucceed(1, fmt.Errorf("executing statement: %w", tc.err), &attempts), fast)
+			require.NoError(t, err)
+			require.Equal(t, 2, attempts)
+		})
+	}
+
+	t.Run("a cancelled load stops retrying", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var attempts int
+		err := newCH(3).withBlockRetries(ctx,
+			failThenSucceed(99, driver.ErrBadConn, &attempts), fast)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, attempts, "the send in flight is not abandoned, but nothing follows it")
+	})
+}


### PR DESCRIPTION
# Description

A single block failure fails the whole table load, and the retry above it restarts the table from scratch. One upload was retried several times in a day, each attempt re-inserting ~11M rows over one transient connection failure.

### Why the split into `readBlock` / `sendBlock` is required, not cosmetic

The rows come off a `csv.Reader` shared with the caller. Retrying the previous shape would have pulled the **next** rows rather than resending the failed ones — skipping a block's worth of data and reporting success. Reading the block before sending it is what makes a retry mean the same thing twice.

Binding still happens per attempt rather than up front, so what is held is the block's raw text and not bound values.

### What retries

Only connection-level failures, since the pool can hand over a socket the server closed while it sat idle:

```go
errors.Is(err, driver.ErrBadConn) ||
	errors.Is(err, io.EOF) ||
	errors.Is(err, syscall.EPIPE) ||
	errors.Is(err, syscall.ECONNRESET)
// plus *net.OpError
```

Anything the server actually rejected is deterministic and returns through `backoff.Permanent`. Bounded by `Warehouse.clickhouse.v2.blockRetries`, default `3`, `0` disables.

### Duplicate rows on a retry

The nastiest case is a send that reached the server but whose ack was lost. We resend a byte-identical block, so ClickHouse's insert deduplication covers it — but only on replicated tables:

| setting | value | applies to |
| --- | --- | --- |
| `replicated_deduplication_window` | `10000` | Replicated / SharedMergeTree — **covered** |
| `replicated_deduplication_window_seconds` | `3600` | as above |
| `non_replicated_deduplication_window` | `0` | plain MergeTree — **not covered** |

Values read from a ClickHouse Cloud 26.4 service. Self-hosted non-replicated deployments do not get this safety net.

### Memory

Holding the block makes `commitEvery` a memory knob as well as a batching one — roughly `commitEvery × row size` resident per concurrent load. At the current default of `1000000` that is substantial on a wide table, and worth lowering to the 100k–250k range on rollout.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-7100/crew-workspace-loading-is-taking-lot-of-time

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
