### PR TITLE
fix(warehouse): instrument the clickhouse v2 load path

### DIFF
--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -42,6 +42,24 @@ var (
 		"schema_snapshot_compression_ratio": {
 			0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 5, 10,
 		},
+		// A block is a row count bounded by commitEvery, not a duration, so it
+		// has nothing in common with the second-scale default and would land
+		// entirely in the overflow bucket without these.
+		"warehouse.clickhouse.blockSize": {
+			1, 10, 100, 1000, 5000, 10000, 25000, 50000, 100000, 250000, 500000, 1000000, 2500000,
+		},
+		// The per-block phases resolve below the 0.1s the warehouse default
+		// starts at: preparing is a single round trip, and reading and binding
+		// scale with commitEvery rather than with the table.
+		"warehouse.clickhouse.blockPrepareTime": {
+			0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+		},
+		"warehouse.clickhouse.blockReadTime": {
+			0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
+		},
+		"warehouse.clickhouse.blockBindTime": {
+			0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
+		},
 		"warehouse_consolidated_schema_size": {
 			float64(10 * bytesize.B), float64(100 * bytesize.B),
 			float64(1 * bytesize.KB), float64(5 * bytesize.KB), float64(10 * bytesize.KB), float64(50 * bytesize.KB), float64(100 * bytesize.KB), float64(500 * bytesize.KB),

--- a/warehouse/integrations/clickhouse/load_v2.go
+++ b/warehouse/integrations/clickhouse/load_v2.go
@@ -109,10 +109,13 @@ func (ch *ClickhouseV2) loadTable(ctx context.Context, tableName string, tableSc
 			return err
 		}
 	}
+	st := ch.newLoadStats(tableName)
+	defer st.loadTableTime.RecordDuration()()
+
 	if ch.UseS3CopyEngineForLoading() {
 		return ch.loadByCopyCommand(ctx, tableName, tableSchemaInUpload)
 	}
-	return ch.loadByDownloadingLoadFiles(ctx, tableName, tableSchemaInUpload)
+	return ch.loadByDownloadingLoadFiles(ctx, tableName, tableSchemaInUpload, st)
 }
 
 func (ch *ClickhouseV2) UseS3CopyEngineForLoading() bool {
@@ -209,7 +212,7 @@ func copySQLStatement(namespace, tableName, sortedColumnNames string, s3Args []s
 	)
 }
 
-func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) error {
+func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema, st *loadStats) error {
 	log := ch.logger.Withn(
 		logger.NewStringField(logfield.SourceID, ch.Warehouse.Source.ID),
 		logger.NewStringField(logfield.SourceType, ch.Warehouse.Source.SourceDefinition.Name),
@@ -221,7 +224,9 @@ func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableNam
 	)
 	log.Infon("Starting load by downloading load files")
 
+	downloadStart := time.Now()
 	fileNames, err := ch.LoadFileDownloader.Download(ctx, tableName)
+	st.downloadLoadFilesTime.Since(downloadStart)
 	if err != nil {
 		return fmt.Errorf("downloading load files: %w", err)
 	}
@@ -229,7 +234,7 @@ func (ch *ClickhouseV2) loadByDownloadingLoadFiles(ctx context.Context, tableNam
 		misc.RemoveFilePaths(fileNames...)
 	}()
 
-	if err := ch.loadTableFromFiles(ctx, log, tableName, tableSchemaInUpload, fileNames); err != nil {
+	if err := ch.loadTableFromFiles(ctx, log, tableName, tableSchemaInUpload, fileNames, st); err != nil {
 		return fmt.Errorf("loading table from files: %w", err)
 	}
 	log.Infon("Completed load by downloading load files")
@@ -331,6 +336,7 @@ func (ch *ClickhouseV2) loadTableFromFiles(
 	tableName string,
 	tableSchemaInUpload model.TableSchema,
 	fileNames []string,
+	st *loadStats,
 ) error {
 	if len(fileNames) == 0 {
 		return nil
@@ -370,7 +376,7 @@ func (ch *ClickhouseV2) loadTableFromFiles(
 	var rows int
 	csvReader := csv.NewReader(gzipReader)
 	for {
-		inserted, err := ch.insertBlock(ctx, insertSQL, csvReader, sortedColumnKeys, tableSchemaInUpload)
+		inserted, err := ch.insertBlock(ctx, insertSQL, csvReader, sortedColumnKeys, tableSchemaInUpload, st)
 		if err != nil {
 			return fmt.Errorf("inserting block after %d rows: %w", rows, err)
 		}
@@ -382,6 +388,8 @@ func (ch *ClickhouseV2) loadTableFromFiles(
 			break
 		}
 	}
+
+	st.numRowsLoadFile.Count(rows)
 
 	log.Debugn("Load files processed",
 		logger.NewIntField("files", int64(len(fileNames))),
@@ -410,18 +418,29 @@ func (ch *ClickhouseV2) insertBlock(
 	csvReader *csv.Reader,
 	columnKeys []string,
 	schema model.TableSchema,
+	st *loadStats,
 ) (int, error) {
+	readStart := time.Now()
 	block, err := readBlock(csvReader, columnKeys, ch.config.commitEvery)
 	if err != nil {
 		return 0, err
 	}
+	st.blockReadTime.Since(readStart)
 	if len(block) == 0 {
 		return 0, nil
 	}
 
+	st.blocks.Increment()
+	st.blockSize.Observe(float64(len(block)))
+
+	// WithNotify fires only once a retry is actually going to follow — after the
+	// permanent check and after the budget check — so this counts retries made,
+	// not failures seen.
 	if err := ch.withBlockRetries(ctx, func() error {
-		return ch.sendBlock(ctx, insertSQL, block, columnKeys, schema)
-	}); err != nil {
+		return ch.sendBlock(ctx, insertSQL, block, columnKeys, schema, st)
+	}, backoff.WithNotify(func(error, time.Duration) {
+		st.blockRetries.Increment()
+	})); err != nil {
 		return 0, err
 	}
 	return len(block), nil
@@ -483,14 +502,23 @@ func readBlock(csvReader *csv.Reader, columnKeys []string, size int) ([][]string
 // sendBlock binds every row and commits the batch. Binding happens here rather
 // than in readBlock so a retry rebinds from the raw text, which keeps the held
 // block as small as it can be.
+// The three phases are timed apart on purpose. Each is bounded by something
+// different — prepare is a round trip, binding is client CPU, and the commit is
+// the one wire write a block makes — and only their ratio says where a slow load
+// is actually spending its time. Timed together they cannot tell a saturated
+// server from a saturated loader, which is the question worth asking before
+// adding any concurrency.
 func (ch *ClickhouseV2) sendBlock(
 	ctx context.Context,
 	insertSQL string,
 	block [][]string,
 	columnKeys []string,
 	schema model.TableSchema,
+	st *loadStats,
 ) error {
-	return ch.DB.WithTx(ctx, func(txCtx context.Context, txn *sqlmw.Tx) error {
+	var boundAt time.Time
+
+	err := ch.DB.WithTx(ctx, func(txCtx context.Context, txn *sqlmw.Tx) error {
 		// A *sql.Stmt belongs to its transaction, and sending a batch is what
 		// ends one, so every block prepares the same SQL again on a fresh
 		// transaction.
@@ -498,23 +526,39 @@ func (ch *ClickhouseV2) sendBlock(
 		// txCtx rather than ctx: the driver captures this context on the batch,
 		// and it is the only one batch.Send can observe. Whatever deadline it
 		// carries is what bounds the write.
+		prepareStart := time.Now()
 		stmt, err := txn.PrepareContext(txCtx, insertSQL)
 		if err != nil {
 			return fmt.Errorf("preparing statement %s: %w", insertSQL, err)
 		}
+		st.blockPrepareTime.Since(prepareStart)
 		defer func() { _ = stmt.Close() }()
 
+		bindStart := time.Now()
 		for _, record := range block {
 			values := make([]any, 0, len(record))
 			for index, value := range record {
 				values = append(values, ch.bindValue(value, schema[columnKeys[index]]))
 			}
+			// Client-side only: ExecContext appends to the batch and sends
+			// nothing, which is why this is counted as binding rather than as
+			// part of the write.
 			if _, err := stmt.ExecContext(txCtx, values...); err != nil {
 				return fmt.Errorf("executing statement: %w", err)
 			}
 		}
+		st.blockBindTime.Since(bindStart)
+		boundAt = time.Now()
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	// WithTx commits once fn returns, and the driver's Commit is batch.Send. The
+	// interval from the last bind to here is therefore the wire write and
+	// nothing else.
+	st.commitTime.Since(boundAt)
+	return nil
 }
 
 // isRetryableSendError reports whether a failed block send is worth repeating.

--- a/warehouse/integrations/clickhouse/stats_v2.go
+++ b/warehouse/integrations/clickhouse/stats_v2.go
@@ -1,0 +1,50 @@
+package clickhouse
+
+import (
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+// loadStats are the measurements one table load produces.
+//
+// The names match v1's wherever the concept is the same, so a destination
+// moving between the two implementations stays comparable on one dashboard.
+// The block-level ones have no v1 counterpart: v1 commits a table once, while
+// v2 commits every commitEvery rows, and how those blocks behave is the thing
+// worth watching during a migration.
+type loadStats struct {
+	numRowsLoadFile       stats.Counter
+	downloadLoadFilesTime stats.Timer
+	loadTableTime         stats.Timer
+	blockReadTime         stats.Timer
+	blockPrepareTime      stats.Timer
+	blockBindTime         stats.Timer
+	commitTime            stats.Timer
+	blockSize             stats.Histogram
+	blocks                stats.Counter
+	blockRetries          stats.Counter
+}
+
+func (ch *ClickhouseV2) newLoadStats(tableName string) *loadStats {
+	tags := stats.Tags{
+		"workspaceId": ch.Warehouse.WorkspaceID,
+		"destination": ch.Warehouse.Destination.ID,
+		"destType":    ch.Warehouse.Type,
+		"source":      ch.Warehouse.Source.ID,
+		"identifier":  ch.Warehouse.Identifier,
+		"tableName":   warehouseutils.TableNameForStats(tableName),
+	}
+	return &loadStats{
+		numRowsLoadFile:       ch.stats.NewTaggedStat("warehouse.clickhouse.numRowsLoadFile", stats.CountType, tags),
+		downloadLoadFilesTime: ch.stats.NewTaggedStat("warehouse.clickhouse.downloadLoadFilesTime", stats.TimerType, tags),
+		loadTableTime:         ch.stats.NewTaggedStat("warehouse.clickhouse.loadTableTime", stats.TimerType, tags),
+		blockReadTime:         ch.stats.NewTaggedStat("warehouse.clickhouse.blockReadTime", stats.TimerType, tags),
+		blockPrepareTime:      ch.stats.NewTaggedStat("warehouse.clickhouse.blockPrepareTime", stats.TimerType, tags),
+		blockBindTime:         ch.stats.NewTaggedStat("warehouse.clickhouse.blockBindTime", stats.TimerType, tags),
+		commitTime:            ch.stats.NewTaggedStat("warehouse.clickhouse.commitTime", stats.TimerType, tags),
+		blockSize:             ch.stats.NewTaggedStat("warehouse.clickhouse.blockSize", stats.HistogramType, tags),
+		blocks:                ch.stats.NewTaggedStat("warehouse.clickhouse.blocks", stats.CountType, tags),
+		blockRetries:          ch.stats.NewTaggedStat("warehouse.clickhouse.blockRetries", stats.CountType, tags),
+	}
+}


### PR DESCRIPTION
# Description

> Stacked on #7354 — review that one first; this PR's diff is only the instrumentation.

The v2 loader carried a `stats` handle and never used it, so the whole path was unobserved where v1 emitted seven measurements. A destination moving to v2 lost every load metric it had. This restores them rather than adding anything new.

### Metrics

| metric | v1 counterpart |
| --- | --- |
| `warehouse.clickhouse.numRowsLoadFile` | same name |
| `warehouse.clickhouse.downloadLoadFilesTime` | same name |
| `warehouse.clickhouse.loadTableTime` | same name |
| `warehouse.clickhouse.commitTime` | same name, same meaning |
| `warehouse.clickhouse.blockReadTime` | none |
| `warehouse.clickhouse.blockPrepareTime` | none |
| `warehouse.clickhouse.blockBindTime` | none |
| `warehouse.clickhouse.blockSize` | none |
| `warehouse.clickhouse.blocks` | none |
| `warehouse.clickhouse.blockRetries` | none |

The whole set reuses v1's tag set, so a destination stays comparable across the migration on one dashboard. The block-level metrics have no v1 counterpart because v1 commits a table once and v2 commits every `commitEvery` rows.

### Why a block is timed in four parts

Each part is bounded by something different:

- `blockReadTime` — CSV parse, client CPU
- `blockPrepareTime` — a round trip
- `blockBindTime` — `bindValue` per cell plus the driver's append, client CPU only, because `ExecContext` appends to a client-side batch and sends nothing
- `commitTime` — the single wire write, since the driver's `Commit` is `batch.Send`

Timed together they cannot tell a saturated server from a saturated loader. That ratio is the thing worth knowing before spending concurrency or moving `commitEvery`, both of which are open questions on this path.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-7100/crew-workspace-loading-is-taking-lot-of-time

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
