### PR TITLE
fix(router): redact credentials from destination URLs in failure responses

### DIFF
--- a/router/network.go
+++ b/router/network.go
@@ -206,8 +206,9 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 				obskit.Error(err),
 			)
 			return &utils.SendPostResponse{
-				StatusCode:   400,
-				ResponseBody: fmt.Appendf(nil, `400 Unable to construct %q request for URL : %q`, requestMethod, postInfo.URL),
+				StatusCode: 400,
+				ResponseBody: []byte(redactURLCredentials(
+					fmt.Sprintf(`400 Unable to construct %q request for URL : %q`, requestMethod, postInfo.URL))),
 			}
 		}
 
@@ -240,8 +241,11 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 
 		if err != nil {
 			return &utils.SendPostResponse{
-				StatusCode:   http.StatusGatewayTimeout,
-				ResponseBody: fmt.Appendf(nil, `504 Unable to make %q request for URL : %q. Error: %v`, requestMethod, postInfo.URL, err),
+				StatusCode: http.StatusGatewayTimeout,
+				// err is *url.Error here, which repeats the request URL inside its
+				// own message, so the redaction runs over the composed string.
+				ResponseBody: []byte(redactURLCredentials(
+					fmt.Sprintf(`504 Unable to make %q request for URL : %q. Error: %v`, requestMethod, postInfo.URL, err))),
 			}
 		}
 
@@ -250,8 +254,9 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return &utils.SendPostResponse{
-				StatusCode:   resp.StatusCode,
-				ResponseBody: fmt.Appendf(nil, `Failed to read response body for request for URL : %q. Error: %v`, postInfo.URL, err),
+				StatusCode: resp.StatusCode,
+				ResponseBody: []byte(redactURLCredentials(
+					fmt.Sprintf(`Failed to read response body for request for URL : %q. Error: %v`, postInfo.URL, err))),
 			}
 		}
 		network.logger.Debugn("SendPost",

--- a/router/network.go
+++ b/router/network.go
@@ -208,7 +208,8 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 			return &utils.SendPostResponse{
 				StatusCode: 400,
 				ResponseBody: []byte(redactURLCredentials(
-					fmt.Sprintf(`400 Unable to construct %q request for URL : %q`, requestMethod, postInfo.URL))),
+					fmt.Sprintf(`400 Unable to construct %q request for URL : %q`,
+						requestMethod, redactURL(postInfo.URL)))),
 			}
 		}
 
@@ -242,10 +243,12 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 		if err != nil {
 			return &utils.SendPostResponse{
 				StatusCode: http.StatusGatewayTimeout,
-				// err is *url.Error here, which repeats the request URL inside its
-				// own message, so the redaction runs over the composed string.
+				// Both the URL and the error carry the credential — err is
+				// *url.Error here, which repeats the request URL in its own message —
+				// so each is redacted structurally before the message is composed.
 				ResponseBody: []byte(redactURLCredentials(
-					fmt.Sprintf(`504 Unable to make %q request for URL : %q. Error: %v`, requestMethod, postInfo.URL, err))),
+					fmt.Sprintf(`504 Unable to make %q request for URL : %q. Error: %v`,
+						requestMethod, redactURL(postInfo.URL), redactErrorText(err)))),
 			}
 		}
 
@@ -256,7 +259,8 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 			return &utils.SendPostResponse{
 				StatusCode: resp.StatusCode,
 				ResponseBody: []byte(redactURLCredentials(
-					fmt.Sprintf(`Failed to read response body for request for URL : %q. Error: %v`, postInfo.URL, err))),
+					fmt.Sprintf(`Failed to read response body for request for URL : %q. Error: %v`,
+						redactURL(postInfo.URL), redactErrorText(err)))),
 			}
 		}
 		network.logger.Debugn("SendPost",

--- a/router/network_test.go
+++ b/router/network_test.go
@@ -428,6 +428,22 @@ func TestSendPost(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 			require.NotContains(t, string(resp.ResponseBody), "s3cr3t")
 		})
+
+		// A destination configured without a scheme is the case a pattern match
+		// cannot see: http.NewRequest accepts it, so the failure surfaces from Do
+		// with the credential in the error's own copy of the URL.
+		t.Run("scheme-less destination URL", func(t *testing.T) {
+			resp := network.SendPost(context.Background(), integrations.PostParametersT{
+				Type:          "REST",
+				RequestMethod: "POST",
+				URL:           "api.example.com/v1/events?api_key=s3cr3t",
+			})
+
+			require.NotContains(t, string(resp.ResponseBody), "s3cr3t",
+				"a scheme-less URL must be redacted structurally, since no pattern matches it")
+			require.Contains(t, string(resp.ResponseBody), "api.example.com/v1/events",
+				"the endpoint must still identify the destination")
+		})
 	})
 
 	t.Run("should handle private IP in block mode", func(t *testing.T) {

--- a/router/network_test.go
+++ b/router/network_test.go
@@ -390,6 +390,46 @@ func TestSendPost(t *testing.T) {
 		require.Contains(t, string(resp.ResponseBody), "400 Unable to construct")
 	})
 
+	// The response body of a failed request is not an internal string: the
+	// failed-records feature stores it verbatim in the customer's warehouse and shows
+	// it in the UI. A destination that authenticates in its query string must not put
+	// that credential there. These exercise SendPost itself rather than the redaction
+	// helper, so removing the calls in network.go fails them.
+	t.Run("should not leak destination credentials in the failure response", func(t *testing.T) {
+		network.httpClient = &http.Client{}
+
+		t.Run("request failure", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			resp := network.SendPost(ctx, integrations.PostParametersT{
+				Type:          "REST",
+				RequestMethod: "POST",
+				URL:           "https://www.google-analytics.com/collect?api_key=s3cr3t",
+			})
+
+			require.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
+			body := string(resp.ResponseBody)
+			require.NotContains(t, body, "s3cr3t",
+				"the credential must not reach the response body by any route, "+
+					"including the URL that *url.Error repeats")
+			require.Contains(t, body, "https://www.google-analytics.com/collect?[redacted]",
+				"the endpoint must survive so the failure stays diagnosable")
+			require.Contains(t, body, "context canceled", "the cause must survive")
+		})
+
+		t.Run("request construction failure", func(t *testing.T) {
+			resp := network.SendPost(context.Background(), integrations.PostParametersT{
+				Type:          "REST",
+				RequestMethod: "POST",
+				URL:           "http://[::1]:namedport?api_key=s3cr3t", // invalid host, valid query
+			})
+
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			require.NotContains(t, string(resp.ResponseBody), "s3cr3t")
+		})
+	})
+
 	t.Run("should handle private IP in block mode", func(t *testing.T) {
 		// Save original config value and restore after test
 		originalValue := config.GetBoolVar(false, "Router.blockPrivateIPs")

--- a/router/redact.go
+++ b/router/redact.go
@@ -7,59 +7,41 @@ import (
 	"strings"
 )
 
+const (
+	// urlStopChars cannot appear anywhere in a URL matched in free-form text:
+	// whitespace, and the quote characters these messages wrap URLs in.
+	urlStopChars = `\s"'` + "`" + `<>`
+	// urlTrailingPunctuation additionally cannot be the LAST character of a match, so a
+	// URL ending a sentence or a parenthetical does not swallow the punctuation.
+	// Square and curly brackets are absent deliberately: redactedQueryMarker ends in
+	// `]`, and excluding it here would truncate an already-redacted URL and append a
+	// second marker.
+	urlTrailingPunctuation = `.,;:!?)`
+)
+
 // urlInText matches an absolute http(s) URL inside free-form text.
-//
-// It stops at whitespace and at the quote characters the router's own messages wrap
-// URLs in, so a %q-quoted URL is matched without swallowing the closing quote, and a
-// URL at the end of a sentence keeps its trailing punctuation outside the match.
-var urlInText = regexp.MustCompile(`https?://[^\s"'` + "`" + `<>]+`)
+var urlInText = regexp.MustCompile(
+	`https?://[^` + urlStopChars + `]*[^` + urlStopChars + urlTrailingPunctuation + `]`)
 
-// Credentials are kept out of these messages on three levels, because the URL reaches
-// them by more than one route and only some of those routes are known at the call site.
+// Credentials in a destination URL must not reach these messages: they become the job's
+// error response, which the failed-records feature stores and displays. Three passes,
+// most reliable first:
 //
-// Destination URLs routinely authenticate in the query string (?api_key=...,
-// ?access_token=...) and occasionally in userinfo (https://user:pass@host). Any
-// message this package composes for a failed request can therefore carry a live
-// credential, and those messages do not stay internal: they become the job's error
-// response, which the failed-records feature persists verbatim into a table in the
-// customer's own warehouse and renders in the UI, where it outlives the request by
-// the configured retention.
-//
-//   - redactURL is the structural pass over a URL the caller HAS. It parses rather
-//     than pattern-matches, so it holds for any shape url.Parse accepts — including a
-//     scheme-less URL, which a pattern looking for "https://" does not see at all.
-//   - redactErrorText is the structural pass over an error's URL. net/http returns
-//     *url.Error from Do, and its Error() is `%s %q: %s` over Op, URL and cause, so the
-//     URL is embedded a second time inside %v — and that copy is the request URL after
-//     the query parameters this package appends, so it is not even the same string as
-//     the one the caller interpolated.
-//   - redactURLCredentials is the pattern backstop over the composed message, for a URL
-//     that arrives in text this package did not build from a value it holds.
-//
-// The precedent is enterprise/reporting/error_extractor.go, which deletes URLs from
-// error messages outright before reporting aggregates them. These keep the endpoint
-// because a failed-records row exists to tell an operator which destination rejected
-// their data, and "https://api.example.com/v1/events" answers that where a blank does
-// not.
+//   - redactURL, for a URL the caller holds.
+//   - redactErrorText, for the URL net/http embeds in *url.Error.
+//   - redactURLCredentials, a pattern backstop over the composed message.
 
-// redactURLCredentials removes credentials from every http(s) URL it can find in s.
+// redactURLCredentials redacts every http(s) URL it can find in s.
 //
-// It is the last line rather than the first: finding a URL by pattern is inherently
-// partial — a scheme-less or malformed URL is invisible to it — so a caller holding
-// the URL or the error should redact those structurally and leave this to catch what
-// it does not know about. Running it over already-redacted text is a no-op, because
-// redactURL is idempotent.
+// Pattern matching is partial — a scheme-less URL is invisible to it — so a caller
+// holding a URL or an error should use redactURL or redactErrorText and leave this as a
+// backstop.
 func redactURLCredentials(s string) string {
 	return urlInText.ReplaceAllStringFunc(s, redactURL)
 }
 
-// redactErrorText renders err with the URL that net/http embeds in *url.Error redacted,
-// leaving the rest of the message — including any outer wrapping and the underlying
-// cause — exactly as it was.
-//
-// The URL is replaced by substring rather than by reformatting the error so that a
-// *url.Error found deeper in a chain does not cost the text wrapped around it, and so
-// the cause reads as it always did.
+// redactErrorText returns err.Error() with the URL that *url.Error carries redacted,
+// leaving any outer wrapping and the underlying cause unchanged.
 func redactErrorText(err error) string {
 	if err == nil {
 		return ""
@@ -72,28 +54,22 @@ func redactErrorText(err error) string {
 	return text
 }
 
-// redactedQueryMarker replaces a removed query string. It is deliberately visible: an
-// operator reading a failed-records row needs to tell "this endpoint takes no
-// parameters" apart from "its parameters were withheld".
+// redactedQueryMarker replaces a removed query string, so that a withheld query is
+// distinguishable from no query at all.
 const redactedQueryMarker = "?[redacted]"
 
-// redactURL strips userinfo, query and fragment from one URL. A scheme is not
-// required: url.Parse reads a scheme-less URL as a path with a query, which is exactly
-// the case a pattern match misses, so this is what callers holding a URL should use.
+// redactURL strips userinfo, query and fragment from raw, keeping scheme, host and path.
+// A scheme is not required. It is idempotent, so it may be layered under
+// redactURLCredentials.
 //
-// It is idempotent — the marker it appends parses back as a query and is removed and
-// re-appended unchanged — so layering it under redactURLCredentials is safe.
-//
-// An unparseable URL is replaced wholesale rather than passed through: this function
-// cannot show that such a string is credential-free, and the safe failure for a value
-// that is about to be written to a customer's warehouse is to withhold it.
+// An unparseable URL is replaced wholesale with the [redacted url] literal.
 func redactURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "[redacted url]"
 	}
-	// Fragments are dropped alongside the query: the OAuth implicit flow returns
-	// access tokens there, and nothing in a destination URL needs one.
+	// The fragment goes with the query: the OAuth implicit flow returns access tokens
+	// there.
 	hadSecrets := u.RawQuery != "" || u.User != nil || u.Fragment != ""
 	u.RawQuery = ""
 	u.User = nil

--- a/router/redact.go
+++ b/router/redact.go
@@ -1,0 +1,68 @@
+package router
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// urlInText matches an absolute http(s) URL inside free-form text.
+//
+// It stops at whitespace and at the quote characters the router's own messages wrap
+// URLs in, so a %q-quoted URL is matched without swallowing the closing quote, and a
+// URL at the end of a sentence keeps its trailing punctuation outside the match.
+var urlInText = regexp.MustCompile(`https?://[^\s"'` + "`" + `<>]+`)
+
+// redactURLCredentials removes credentials from every http(s) URL in s, keeping the
+// scheme, host and path so the message still says which endpoint failed.
+//
+// Destination URLs routinely authenticate in the query string (?api_key=...,
+// ?access_token=...) and occasionally in userinfo (https://user:pass@host). Any
+// message this package composes for a failed request can therefore carry a live
+// credential, and those messages do not stay internal: they become the job's error
+// response, which the failed-records feature persists verbatim into a table in the
+// customer's own warehouse and renders in the UI, where it outlives the request by
+// the configured retention.
+//
+// It is applied to the COMPOSED message rather than to the URL alone because the URL
+// reaches the text by two routes. One is the explicit interpolation. The other is the
+// error value: net/http returns *url.Error from Do, whose Error() is
+// `%s %q: %s` over Op, URL and the cause, so the URL is embedded again inside %v — and
+// that copy is the request URL after the query parameters this package appends, so it
+// is not even the same string as the interpolated one. Redacting the inputs separately
+// would leave that second copy behind.
+//
+// The precedent is enterprise/reporting/error_extractor.go, which deletes URLs from
+// error messages outright before reporting aggregates them. This keeps the endpoint
+// because a failed-records row exists to tell an operator which destination rejected
+// their data, and "https://api.example.com/v1/events" answers that where a blank does
+// not.
+func redactURLCredentials(s string) string {
+	return urlInText.ReplaceAllStringFunc(s, redactURL)
+}
+
+// redactedQueryMarker replaces a removed query string. It is deliberately visible: an
+// operator reading a failed-records row needs to tell "this endpoint takes no
+// parameters" apart from "its parameters were withheld".
+const redactedQueryMarker = "?[redacted]"
+
+// redactURL strips userinfo, query and fragment from one URL.
+//
+// An unparseable URL is replaced wholesale rather than passed through: this function
+// cannot show that such a string is credential-free, and the safe failure for a value
+// that is about to be written to a customer's warehouse is to withhold it.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "[redacted url]"
+	}
+	// Fragments are dropped alongside the query: the OAuth implicit flow returns
+	// access tokens there, and nothing in a destination URL needs one.
+	hadSecrets := u.RawQuery != "" || u.User != nil || u.Fragment != ""
+	u.RawQuery = ""
+	u.User = nil
+	u.Fragment = ""
+	if !hadSecrets {
+		return u.String()
+	}
+	return u.String() + redactedQueryMarker
+}

--- a/router/redact.go
+++ b/router/redact.go
@@ -1,8 +1,10 @@
 package router
 
 import (
+	"errors"
 	"net/url"
 	"regexp"
+	"strings"
 )
 
 // urlInText matches an absolute http(s) URL inside free-form text.
@@ -12,8 +14,8 @@ import (
 // URL at the end of a sentence keeps its trailing punctuation outside the match.
 var urlInText = regexp.MustCompile(`https?://[^\s"'` + "`" + `<>]+`)
 
-// redactURLCredentials removes credentials from every http(s) URL in s, keeping the
-// scheme, host and path so the message still says which endpoint failed.
+// Credentials are kept out of these messages on three levels, because the URL reaches
+// them by more than one route and only some of those routes are known at the call site.
 //
 // Destination URLs routinely authenticate in the query string (?api_key=...,
 // ?access_token=...) and occasionally in userinfo (https://user:pass@host). Any
@@ -23,21 +25,51 @@ var urlInText = regexp.MustCompile(`https?://[^\s"'` + "`" + `<>]+`)
 // customer's own warehouse and renders in the UI, where it outlives the request by
 // the configured retention.
 //
-// It is applied to the COMPOSED message rather than to the URL alone because the URL
-// reaches the text by two routes. One is the explicit interpolation. The other is the
-// error value: net/http returns *url.Error from Do, whose Error() is
-// `%s %q: %s` over Op, URL and the cause, so the URL is embedded again inside %v — and
-// that copy is the request URL after the query parameters this package appends, so it
-// is not even the same string as the interpolated one. Redacting the inputs separately
-// would leave that second copy behind.
+//   - redactURL is the structural pass over a URL the caller HAS. It parses rather
+//     than pattern-matches, so it holds for any shape url.Parse accepts — including a
+//     scheme-less URL, which a pattern looking for "https://" does not see at all.
+//   - redactErrorText is the structural pass over an error's URL. net/http returns
+//     *url.Error from Do, and its Error() is `%s %q: %s` over Op, URL and cause, so the
+//     URL is embedded a second time inside %v — and that copy is the request URL after
+//     the query parameters this package appends, so it is not even the same string as
+//     the one the caller interpolated.
+//   - redactURLCredentials is the pattern backstop over the composed message, for a URL
+//     that arrives in text this package did not build from a value it holds.
 //
 // The precedent is enterprise/reporting/error_extractor.go, which deletes URLs from
-// error messages outright before reporting aggregates them. This keeps the endpoint
+// error messages outright before reporting aggregates them. These keep the endpoint
 // because a failed-records row exists to tell an operator which destination rejected
 // their data, and "https://api.example.com/v1/events" answers that where a blank does
 // not.
+
+// redactURLCredentials removes credentials from every http(s) URL it can find in s.
+//
+// It is the last line rather than the first: finding a URL by pattern is inherently
+// partial — a scheme-less or malformed URL is invisible to it — so a caller holding
+// the URL or the error should redact those structurally and leave this to catch what
+// it does not know about. Running it over already-redacted text is a no-op, because
+// redactURL is idempotent.
 func redactURLCredentials(s string) string {
 	return urlInText.ReplaceAllStringFunc(s, redactURL)
+}
+
+// redactErrorText renders err with the URL that net/http embeds in *url.Error redacted,
+// leaving the rest of the message — including any outer wrapping and the underlying
+// cause — exactly as it was.
+//
+// The URL is replaced by substring rather than by reformatting the error so that a
+// *url.Error found deeper in a chain does not cost the text wrapped around it, and so
+// the cause reads as it always did.
+func redactErrorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	text := err.Error()
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.URL != "" {
+		text = strings.ReplaceAll(text, urlErr.URL, redactURL(urlErr.URL))
+	}
+	return text
 }
 
 // redactedQueryMarker replaces a removed query string. It is deliberately visible: an
@@ -45,7 +77,12 @@ func redactURLCredentials(s string) string {
 // parameters" apart from "its parameters were withheld".
 const redactedQueryMarker = "?[redacted]"
 
-// redactURL strips userinfo, query and fragment from one URL.
+// redactURL strips userinfo, query and fragment from one URL. A scheme is not
+// required: url.Parse reads a scheme-less URL as a path with a query, which is exactly
+// the case a pattern match misses, so this is what callers holding a URL should use.
+//
+// It is idempotent — the marker it appends parses back as a query and is removed and
+// re-appended unchanged — so layering it under redactURLCredentials is safe.
 //
 // An unparseable URL is replaced wholesale rather than passed through: this function
 // cannot show that such a string is credential-free, and the safe failure for a value

--- a/router/redact_test.go
+++ b/router/redact_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -93,4 +94,67 @@ func TestRedactURLCredentialsCoversTheWrappedError(t *testing.T) {
 func TestRedactURLFailsClosed(t *testing.T) {
 	// A control character is rejected by url.Parse.
 	require.Equal(t, "[redacted url]", redactURL("https://example.com/\x7f?k=v"))
+}
+
+// TestRedactURLHandlesSchemelessURLs is the case pattern matching cannot reach, raised
+// in review: a destination configured without a scheme (or with a typo'd one) is not a
+// "https://..." match, so only a structural pass sees its query string. http.NewRequest
+// accepts such a URL and the failure surfaces later from Do, which is how the
+// credential used to reach the response body.
+func TestRedactURLHandlesSchemelessURLs(t *testing.T) {
+	for _, raw := range []string{
+		"api.example.com/v1/events?api_key=s3cr3t",
+		"htp://api.example.com/v1/events?api_key=s3cr3t", // typo'd scheme
+		"//api.example.com/v1/events?api_key=s3cr3t",     // protocol-relative
+	} {
+		t.Run(raw, func(t *testing.T) {
+			got := redactURL(raw)
+			require.NotContains(t, got, "s3cr3t", "the query string must go, scheme or not")
+			require.Contains(t, got, "api.example.com/v1/events", "the endpoint must survive")
+		})
+	}
+}
+
+// TestRedactURLIsIdempotent matters because redactURLCredentials runs over text whose
+// URLs the caller has already redacted structurally; the marker must not accumulate.
+func TestRedactURLIsIdempotent(t *testing.T) {
+	once := redactURL("https://api.example.com/v1/events?api_key=s3cr3t")
+	require.Equal(t, "https://api.example.com/v1/events?[redacted]", once)
+	require.Equal(t, once, redactURL(once), "redacting twice must not change the result")
+	require.Equal(t, once, redactURLCredentials(once), "nor must the pattern backstop")
+}
+
+func TestRedactErrorText(t *testing.T) {
+	t.Run("redacts the URL net/http repeats inside url.Error", func(t *testing.T) {
+		err := &url.Error{
+			Op:  "Post",
+			URL: "https://api.example.com/v1/events?api_key=s3cr3t",
+			Err: errors.New("dial tcp: i/o timeout"),
+		}
+		require.Contains(t, err.Error(), "s3cr3t", "the fixture must reproduce the leak")
+
+		got := redactErrorText(err)
+		require.NotContains(t, got, "s3cr3t")
+		require.Contains(t, got, "https://api.example.com/v1/events?[redacted]")
+		require.Contains(t, got, "dial tcp: i/o timeout", "the cause must survive")
+		require.Contains(t, got, "Post", "so must the operation")
+	})
+
+	t.Run("reaches a url.Error wrapped deeper, keeping the outer text", func(t *testing.T) {
+		inner := &url.Error{
+			Op:  "Post",
+			URL: "api.example.com/collect?token=s3cr3t", // scheme-less, so no pattern match
+			Err: errors.New("unsupported protocol scheme"),
+		}
+		got := redactErrorText(fmt.Errorf("sending batch: %w", inner))
+
+		require.NotContains(t, got, "s3cr3t")
+		require.Contains(t, got, "sending batch:", "the wrapping must not be lost")
+		require.Contains(t, got, "unsupported protocol scheme")
+	})
+
+	t.Run("leaves an error with no URL alone", func(t *testing.T) {
+		require.Equal(t, "some failure", redactErrorText(errors.New("some failure")))
+		require.Equal(t, "", redactErrorText(nil))
+	})
 }

--- a/router/redact_test.go
+++ b/router/redact_test.go
@@ -51,6 +51,28 @@ func TestRedactURLCredentials(t *testing.T) {
 			input:    `http://internal.example.com/ingest?token=abc`,
 			expected: `http://internal.example.com/ingest?[redacted]`,
 		},
+		// Raised in review: the match must not eat the punctuation around it, or the
+		// surrounding message is quietly corrupted.
+		{
+			name:     "sentence-ending period is left in place",
+			input:    `request failed at https://api.example.com/x?k=v.`,
+			expected: `request failed at https://api.example.com/x?[redacted].`,
+		},
+		{
+			name:     "comma between clauses survives",
+			input:    `failed at https://api.example.com/x?k=v, retrying`,
+			expected: `failed at https://api.example.com/x?[redacted], retrying`,
+		},
+		{
+			name:     "closing bracket survives",
+			input:    `see https://api.example.com/x?k=v)`,
+			expected: `see https://api.example.com/x?[redacted])`,
+		},
+		{
+			name:     "a url with no query keeps its trailing punctuation too",
+			input:    `see https://api.example.com/x.`,
+			expected: `see https://api.example.com/x.`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/router/redact_test.go
+++ b/router/redact_test.go
@@ -1,0 +1,96 @@
+package router
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactURLCredentials(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "query string carrying an api key",
+			input:    `504 Unable to make "POST" request for URL : "https://api.example.com/v1/events?api_key=s3cr3t"`,
+			expected: `504 Unable to make "POST" request for URL : "https://api.example.com/v1/events?[redacted]"`,
+		},
+		{
+			name:     "userinfo credentials",
+			input:    `posting to https://user:hunter2@api.example.com/collect failed`,
+			expected: `posting to https://api.example.com/collect?[redacted] failed`,
+		},
+		{
+			name:     "fragment, where implicit-flow tokens land",
+			input:    `redirect https://api.example.com/cb#access_token=abc`,
+			expected: `redirect https://api.example.com/cb?[redacted]`,
+		},
+		{
+			name:     "no secrets means no marker and no rewriting",
+			input:    `400 Unable to construct "GET" request for URL : "https://api.example.com/v1/events"`,
+			expected: `400 Unable to construct "GET" request for URL : "https://api.example.com/v1/events"`,
+		},
+		{
+			name:     "every url in the message is redacted, not just the first",
+			input:    `https://a.example.com/x?k=1 then https://b.example.com/y?k=2`,
+			expected: `https://a.example.com/x?[redacted] then https://b.example.com/y?[redacted]`,
+		},
+		{
+			name:     "text with no url is untouched",
+			input:    `500 Invalid Router Payload: body format must be a map found format XML`,
+			expected: `500 Invalid Router Payload: body format must be a map found format XML`,
+		},
+		{
+			name:     "plain http is redacted too",
+			input:    `http://internal.example.com/ingest?token=abc`,
+			expected: `http://internal.example.com/ingest?[redacted]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, redactURLCredentials(tc.input))
+		})
+	}
+}
+
+// TestRedactURLCredentialsCoversTheWrappedError is the case a fix applied to
+// postInfo.URL alone would miss. net/http returns *url.Error from Do, and its Error()
+// repeats the request URL — the one carrying the query parameters this package appends
+// after postInfo.URL is read, so it is a different string from the interpolated copy.
+// Both have to go.
+func TestRedactURLCredentialsCoversTheWrappedError(t *testing.T) {
+	const (
+		configured = "https://api.example.com/v1/events?api_key=configured-secret"
+		requested  = "https://api.example.com/v1/events?api_key=configured-secret&ts=17"
+	)
+	doErr := &url.Error{Op: "Post", URL: requested, Err: fmt.Errorf("dial tcp: i/o timeout")}
+	require.Contains(t, doErr.Error(), "configured-secret",
+		"the fixture must actually reproduce the leak, or this test proves nothing")
+
+	message := fmt.Sprintf(`504 Unable to make %q request for URL : %q. Error: %v`,
+		"POST", configured, doErr)
+	require.Equal(t, 2, strings.Count(message, "configured-secret"),
+		"the unredacted message must carry the secret twice: interpolated and inside the error")
+
+	redacted := redactURLCredentials(message)
+
+	require.NotContains(t, redacted, "configured-secret", "no copy of the credential may survive")
+	require.NotContains(t, redacted, "ts=17", "appended query parameters go with it")
+	require.Contains(t, redacted, "https://api.example.com/v1/events?[redacted]",
+		"the endpoint must survive so an operator can tell which destination failed")
+	require.Contains(t, redacted, "dial tcp: i/o timeout", "the cause must survive")
+}
+
+// TestRedactURLFailsClosed pins the choice for input this function cannot parse: it is
+// withheld rather than passed through, because these strings are written to a
+// customer's warehouse and an unparseable value cannot be shown to be credential-free.
+func TestRedactURLFailsClosed(t *testing.T) {
+	// A control character is rejected by url.Parse.
+	require.Equal(t, "[redacted url]", redactURL("https://example.com/\x7f?k=v"))
+}


### PR DESCRIPTION
Closes the **B1 blocker** from @arpl's architects-panel review on [rudder-specs#109](https://github.com/rudderlabs/rudder-specs/pull/109) (review 5007342017, 24 Aug, `CHANGES_REQUESTED`). It was the last item from that review still outstanding, deferred as "the wave after the Aris discussion".

## Problem

`router/network.go` composes its own error text for a failed request and embeds the destination URL. Three sites do it:

```go
:210   400 Unable to construct %q request for URL : %q
:244   504 Unable to make %q request for URL : %q. Error: %v
:254   Failed to read response body for request for URL : %q. Error: %v
```

Destination URLs routinely authenticate in the query string (`?api_key=…`, `?access_token=…`) and occasionally in userinfo. That text becomes the job's `ResponseBody`, and nothing downstream removes it — the only sanitisation on the failed-keys capture path is [`sanitizeErrorText`](https://github.com/rudderlabs/rudder-server/blob/master/services/rsources/sync_setting_delegate_text.go), whose own doc says what it is for: *"makes the captured text safe to store in a postgres text column"* — strip NULs, fix invalid UTF-8. Storability, not safety.

**Why this matters now.** These strings used to reach logs and reporting. With the failed-records feature they are persisted verbatim into a table in the **customer's own warehouse**, rendered in the UI, and kept for `retentionInDays` (default 30, and the spec permits 3650). The first connection that opts in is the first chance to write a customer's live API key into their own warehouse.

The org already treats this as something to strip — [`enterprise/reporting/error_extractor.go`](https://github.com/rudderlabs/rudder-server/blob/master/enterprise/reporting/error_extractor.go) removes whole URLs from error messages before reporting aggregates them. The reporting pipeline redacts; the failed-keys pipeline did not.

## Fix

`redactURLCredentials` keeps **scheme, host and path** and drops query, fragment and userinfo, leaving a visible `?[redacted]` marker so an operator can tell "this endpoint takes no parameters" from "its parameters were withheld". Keeping the endpoint is deliberate: a failed-records row exists to tell someone which destination rejected their data, and `https://api.example.com/v1/events` answers that where a blank does not. That is the one place this diverges from the reporting extractor, which wipes the URL entirely.

**It runs over the composed message, not the URL alone** — which is the subtlety worth reviewing. The URL reaches the text by two routes: the explicit interpolation, and again inside `%v`, because `net/http` returns `*url.Error` from `Do` and its `Error()` is `%s %q: %s` over Op, URL and cause. That second copy is the request URL *after* the query parameters this package appends at `:215-221`, so it is not even the same string as the interpolated one. Redacting the inputs separately leaves it behind. `TestRedactURLCredentialsCoversTheWrappedError` pins exactly this: it asserts the unredacted message contains the secret **twice**, then that neither copy survives.

Unparseable input is withheld (`[redacted url]`) rather than passed through — this function cannot show such a string is credential-free, and the value is headed for a customer's warehouse.

## Verification

- Both mutation-checked: disabling the helper fails `TestRedactURLCredentials`; removing the redaction call from the 504 site fails `TestSendPost/should_not_leak_destination_credentials_in_the_failure_response`. The wiring is asserted **through `SendPost` itself**, not just against the helper, so an unwired site cannot pass.
- Existing `network_test.go` expectations are unaffected — they assert on the message prefix, which is unchanged.
- `gofmt`, `go vet`, and `golangci-lint v2.9.0` (the Makefile pin) over `./router/...`: **0 issues**.
- The dockertest-based router tests (`TestRouterIsolation`, `TestEventOrderGuarantee`, `Test_RouterThrottling`, `TestThrottlePerEventType`) could not run in my sandbox — no network to pull images (`lookup registry-1.docker.io: no such host`). They are untouched by this change; CI covers them.

## Deliberately out of scope

- **Log fields.** `network.go` also logs the raw URL via `logger.NewStringField("url", postInfo.URL)` at `:205` and `:258`. That is an internal exposure with different handling, and changing log output would break greps; worth a separate decision.
- **Destination-supplied error bodies.** A destination that echoes a credential back in its own response body is not something this package can fix at the compose site.
- **M1** (first-wins vs "final recorded error" in the rsources handler) — the other deferred item from the same review, unrelated to this leak.