### PR TITLE
fix: close leftover file descriptors after uploads

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/eloqua/eloqua.go
+++ b/router/batchrouter/asyncdestinationmanager/eloqua/eloqua.go
@@ -110,6 +110,7 @@ func (e *EloquaServiceImpl) UploadData(data *HttpRequestData, filePath string) e
 	if err != nil {
 		return err
 	}
+	defer func() { _ = file.Close() }()
 	data.Endpoint = data.BaseEndpoint + e.bulkApi + data.DynamicPart + "/data"
 	data.Method = http.MethodPost
 	data.ContentType = "text/csv"

--- a/router/batchrouter/asyncdestinationmanager/eloqua/upload_close_test.go
+++ b/router/batchrouter/asyncdestinationmanager/eloqua/upload_close_test.go
@@ -1,0 +1,54 @@
+package eloqua
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadDataSuccessAndError(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "bulk.csv")
+	require.NoError(t, os.WriteFile(filePath, []byte("C_EmailAddress\ntest@mail.com\n"), 0o644))
+	svc := NewEloquaServiceImpl("2.0")
+
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(server.Close)
+
+		err := svc.UploadData(&HttpRequestData{
+			BaseEndpoint: server.URL,
+			DynamicPart:  "/imports/1",
+		}, filePath)
+		require.NoError(t, err)
+	})
+
+	t.Run("http error status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		t.Cleanup(server.Close)
+
+		err := svc.UploadData(&HttpRequestData{
+			BaseEndpoint: server.URL,
+			DynamicPart:  "/imports/1",
+		}, filePath)
+		require.Error(t, err)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		err := svc.UploadData(&HttpRequestData{
+			BaseEndpoint: "http://127.0.0.1",
+			DynamicPart:  "/imports/1",
+		}, filepath.Join(t.TempDir(), "missing.csv"))
+		require.Error(t, err)
+	})
+}

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lyticsBulkUpload.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lyticsBulkUpload.go
@@ -58,6 +58,7 @@ func (u *LyticsServiceImpl) UploadBulkFile(data *HttpRequestData, filePath strin
 	if err != nil {
 		return err
 	}
+	defer func() { _ = file.Close() }()
 
 	data.Method = http.MethodPost
 	data.ContentType = "application/csv"

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/upload_close_test.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/upload_close_test.go
@@ -1,0 +1,44 @@
+package lyticsBulkUpload
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadBulkFileSuccessAndError(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "bulk.csv")
+	require.NoError(t, os.WriteFile(filePath, []byte("col1,col2\n1,2\n"), 0o644))
+
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		err := (&LyticsServiceImpl{}).UploadBulkFile(&HttpRequestData{Endpoint: server.URL}, filePath)
+		require.NoError(t, err)
+	})
+
+	t.Run("http error status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+
+		err := (&LyticsServiceImpl{}).UploadBulkFile(&HttpRequestData{Endpoint: server.URL}, filePath)
+		require.Error(t, err)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		err := (&LyticsServiceImpl{}).UploadBulkFile(&HttpRequestData{Endpoint: "http://127.0.0.1"}, filepath.Join(t.TempDir(), "missing.csv"))
+		require.Error(t, err)
+	})
+}

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -384,8 +384,12 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 
 	outputFile, err := os.Open(gzipFilePath)
 	if err != nil {
-		panic(err)
+		return UploadResult{
+			Error:          fmt.Errorf("BRT: Error opening gzip file for upload: %w", err),
+			LocalFilePaths: []string{gzipFilePath},
+		}
 	}
+	defer func() { _ = outputFile.Close() }()
 
 	brt.logger.Debugn("BRT: Starting upload to", logger.NewStringField("provider", provider))
 	var folderName string

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -340,18 +340,22 @@ func (brt *Handle) crashRecover() {
 			err = downloader.Download(context.TODO(), jsonFile, objKey)
 			if err != nil {
 				brt.logger.Errorn("BRT: Failed to download data for incomplete journal entry to recover from", logger.NewStringField("provider", object.Provider), logger.NewStringField("key", object.Key), obskit.Error(err))
+				_ = jsonFile.Close()
+				_ = os.Remove(jsonPath)
 				brt.jobsDB.JournalDeleteEntry(entry.OpID)
 				continue
 			}
 
 			_ = jsonFile.Close()
-			defer func() { _ = os.Remove(jsonPath) }()
 			rawf, err := os.Open(jsonPath)
 			if err != nil {
+				_ = os.Remove(jsonPath)
 				panic(err)
 			}
 			reader, err := gzip.NewReader(rawf)
 			if err != nil {
+				_ = rawf.Close()
+				_ = os.Remove(jsonPath)
 				panic(err)
 			}
 
@@ -367,6 +371,8 @@ func (brt *Handle) crashRecover() {
 				brt.uploadedRawDataJobsCache[object.DestinationID][eventID] = true
 			}
 			_ = reader.Close()
+			_ = rawf.Close()
+			_ = os.Remove(jsonPath)
 			brt.jobsDB.JournalDeleteEntry(entry.OpID)
 		}
 	}

--- a/router/batchrouter/handle_test.go
+++ b/router/batchrouter/handle_test.go
@@ -1,8 +1,11 @@
 package batchrouter
 
 import (
+	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -707,4 +710,159 @@ func TestUploadDatePrefixOverridePrecedence(t *testing.T) {
 			require.Equal(t, tc.expectedDatePrefix, capturedKeyPrefixes[2])
 		})
 	}
+}
+
+func requireFileClosed(t *testing.T, f *os.File) {
+	t.Helper()
+	require.NotNil(t, f)
+	_, err := f.Write([]byte("x"))
+	require.Error(t, err)
+	require.Error(t, f.Close(), "expected file to already be closed")
+}
+
+func TestUploadClosesGzipFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("RUDDER_TMPDIR", tmpDir)
+	config.Reset()
+	config.Set("RUDDER_TMPDIR", tmpDir)
+	t.Cleanup(config.Reset)
+
+	mockCtrl := gomock.NewController(t)
+	mockFileManager := mock_filemanager.NewMockFileManager(mockCtrl)
+	mockFileManager.EXPECT().Prefix().Return("mockPrefix")
+	mockFileManager.EXPECT().ListFilesWithPrefix(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(filemanager.MockListSession([]*filemanager.FileInfo{}, nil))
+
+	var uploadedFile *os.File
+	mockFileManager.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, f *os.File, _ ...string) (filemanager.UploadedFile, error) {
+			uploadedFile = f
+			return filemanager.UploadedFile{Location: "local", ObjectName: "file"}, nil
+		},
+	)
+
+	handle := &Handle{
+		logger: logger.NewLogger().Child("batchrouter"),
+		fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+			return mockFileManager, nil
+		},
+		datePrefixOverride: config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride"),
+		customDatePrefix:   config.GetReloadableStringVar("", "BatchRouter.customDatePrefix"),
+		dateFormatProvider: &storageDateFormatProvider{dateFormatsCache: make(map[string]string)},
+		conf:               config.New(),
+		now:                timeutil.Now,
+		jobsDB:             mocksJobsDB.NewMockJobsDB(mockCtrl),
+	}
+
+	result := handle.upload("S3", &BatchedJobs{
+		Jobs: []*jobsdb.JobT{
+			{EventPayload: []byte(`{"metadata":{"table":"users"}}`)},
+		},
+		Connection: &Connection{
+			Source:      backendconfig.SourceT{ID: "test-source"},
+			Destination: backendconfig.DestinationT{ID: "test-destination"},
+		},
+	}, true)
+
+	require.NoError(t, result.Error)
+	requireFileClosed(t, uploadedFile)
+}
+
+func TestCrashRecoverClosesFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("RUDDER_TMPDIR", tmpDir)
+	config.Reset()
+	config.Set("RUDDER_TMPDIR", tmpDir)
+	t.Cleanup(config.Reset)
+
+	payload, err := jsonrs.Marshal(&ObjectStorageDefinition{
+		Config:          map[string]any{"bucket": "test-bucket", "prefix": "test-prefix"},
+		Key:             "path/to/object.json.gz",
+		Provider:        "S3",
+		DestinationID:   "dest-1",
+		DestinationType: "S3",
+	})
+	require.NoError(t, err)
+
+	entry := jobsdb.JournalEntryT{
+		OpID:      42,
+		OpType:    jobsdb.RawDataDestUploadOperation,
+		OpPayload: payload,
+	}
+
+	t.Run("download failure closes and removes temp file", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFileManager := mock_filemanager.NewMockFileManager(mockCtrl)
+		jobsDB := mocksJobsDB.NewMockJobsDB(mockCtrl)
+
+		var downloadPath string
+		jobsDB.EXPECT().GetJournalEntries(jobsdb.RawDataDestUploadOperation).Return([]jobsdb.JournalEntryT{entry})
+		jobsDB.EXPECT().JournalDeleteEntry(int64(42)).Times(1)
+		mockFileManager.EXPECT().Download(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, w io.WriterAt, _ string, _ ...filemanager.DownloadOption) error {
+				f, ok := w.(*os.File)
+				require.True(t, ok)
+				downloadPath = f.Name()
+				return errors.New("download failed")
+			},
+		)
+
+		brt := &Handle{
+			destType:                 "S3",
+			logger:                   logger.NOP,
+			conf:                     config.New(),
+			jobsDB:                   jobsDB,
+			uploadedRawDataJobsCache: make(map[string]map[string]bool),
+			fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+				return mockFileManager, nil
+			},
+		}
+
+		require.NotPanics(t, brt.crashRecover)
+		require.NotEmpty(t, downloadPath)
+		_, statErr := os.Stat(downloadPath)
+		require.Error(t, statErr)
+		require.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("success populates cache and closes raw file", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFileManager := mock_filemanager.NewMockFileManager(mockCtrl)
+		jobsDB := mocksJobsDB.NewMockJobsDB(mockCtrl)
+
+		var downloadPath string
+		var downloadedFile *os.File
+		jobsDB.EXPECT().GetJournalEntries(jobsdb.RawDataDestUploadOperation).Return([]jobsdb.JournalEntryT{entry})
+		jobsDB.EXPECT().JournalDeleteEntry(int64(42)).Times(1)
+		mockFileManager.EXPECT().Download(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, w io.WriterAt, _ string, _ ...filemanager.DownloadOption) error {
+				f, ok := w.(*os.File)
+				require.True(t, ok)
+				downloadPath = f.Name()
+				downloadedFile = f
+				gz := gzip.NewWriter(f)
+				_, writeErr := gz.Write([]byte(`{"messageId":"msg-1"}` + "\n"))
+				require.NoError(t, writeErr)
+				return gz.Close()
+			},
+		)
+
+		brt := &Handle{
+			destType:                 "S3",
+			logger:                   logger.NOP,
+			conf:                     config.New(),
+			jobsDB:                   jobsDB,
+			uploadedRawDataJobsCache: make(map[string]map[string]bool),
+			fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+				return mockFileManager, nil
+			},
+		}
+
+		require.NotPanics(t, brt.crashRecover)
+		require.True(t, brt.uploadedRawDataJobsCache["dest-1"]["msg-1"])
+		requireFileClosed(t, downloadedFile)
+		_, statErr := os.Stat(downloadPath)
+		require.Error(t, statErr)
+		require.True(t, os.IsNotExist(statErr))
+	})
 }

--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -779,16 +779,17 @@ func (g *GRPC) validateObjectStorage(ctx context.Context, request validateObject
 		_ = os.Remove(tempFilePath)
 	}()
 
-	f, err := os.Open(tempFilePath)
+	uploadFile, err := os.Open(tempFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to open path to temporary file: \n%w", err)
 	}
+	defer func() { _ = uploadFile.Close() }()
 
-	uploadOutput, err := fileManager.Upload(ctx, f)
+	uploadOutput, err := fileManager.Upload(ctx, uploadFile)
 	if err != nil {
 		return invalidDestinationCredErr{Base: err, Operation: "upload"}
 	}
-	if err = f.Close(); err != nil {
+	if err = uploadFile.Close(); err != nil {
 		return fmt.Errorf("unable to close file: \n%w", err)
 	}
 
@@ -802,23 +803,24 @@ func (g *GRPC) validateObjectStorage(ctx context.Context, request validateObject
 		return fmt.Errorf("unable to create download directory: \n%w", err)
 	}
 
-	f, err = os.CreateTemp(downloadDir, downloadFileNamePattern)
+	downloadFile, err := os.CreateTemp(downloadDir, downloadFileNamePattern)
 	if err != nil {
 		return fmt.Errorf("unable to create temp file: \n%w", err)
 	}
 	defer func() {
-		_ = os.Remove(f.Name())
+		_ = downloadFile.Close()
+		_ = os.Remove(downloadFile.Name())
 	}()
 
 	err = fileManager.Download(
 		ctx,
-		f,
+		downloadFile,
 		fileManager.GetDownloadKeyFromFileLocation(uploadOutput.Location),
 	)
 	if err != nil {
 		return invalidDestinationCredErr{Base: err, Operation: "download"}
 	}
-	if err = f.Close(); err != nil {
+	if err = downloadFile.Close(); err != nil {
 		return fmt.Errorf("unable to close file: \n%w", err)
 	}
 	return nil

--- a/warehouse/api/validate_object_storage_test.go
+++ b/warehouse/api/validate_object_storage_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	"github.com/rudderlabs/rudder-go-kit/filemanager/mock_filemanager"
+
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/rudderlabs/rudder-server/warehouse/validations"
+)
+
+func requireFileClosed(t *testing.T, f *os.File) {
+	t.Helper()
+	require.NotNil(t, f)
+	_, err := f.Write([]byte("x"))
+	require.Error(t, err)
+	require.Error(t, f.Close(), "expected file to already be closed")
+}
+
+func TestValidateObjectStorageClosesFiles(t *testing.T) {
+	validations.Init()
+	misc.Init()
+
+	tmpDir := t.TempDir()
+	t.Setenv("RUDDER_TMPDIR", tmpDir)
+	config.Reset()
+	config.Set("RUDDER_TMPDIR", tmpDir)
+	t.Cleanup(config.Reset)
+
+	request := validateObjectStorageRequest{
+		Type:   "S3",
+		Config: map[string]any{"bucketName": "test-bucket"},
+	}
+
+	t.Run("success closes upload and download files", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFileManager := mock_filemanager.NewMockFileManager(mockCtrl)
+		mockFileManager.EXPECT().Prefix().Return("")
+		mockFileManager.EXPECT().ListFilesWithPrefix(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(filemanager.MockListSession(nil, nil))
+
+		var uploadFile, downloadFile *os.File
+		mockFileManager.EXPECT().Upload(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, f *os.File, _ ...string) (filemanager.UploadedFile, error) {
+				uploadFile = f
+				return filemanager.UploadedFile{Location: "s3://bucket/key", ObjectName: "key"}, nil
+			},
+		)
+		mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(gomock.Any()).Return("key")
+		mockFileManager.EXPECT().Download(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, w io.WriterAt, _ string, _ ...filemanager.DownloadOption) error {
+				f, ok := w.(*os.File)
+				require.True(t, ok)
+				downloadFile = f
+				return nil
+			},
+		)
+
+		g := &GRPC{
+			conf: config.New(),
+			fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+				return mockFileManager, nil
+			},
+		}
+
+		require.NoError(t, g.validateObjectStorage(context.Background(), request))
+		requireFileClosed(t, uploadFile)
+		requireFileClosed(t, downloadFile)
+	})
+
+	t.Run("upload error still closes upload file", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFileManager := mock_filemanager.NewMockFileManager(mockCtrl)
+		mockFileManager.EXPECT().Prefix().Return("")
+		mockFileManager.EXPECT().ListFilesWithPrefix(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(filemanager.MockListSession(nil, nil))
+
+		var uploadFile *os.File
+		mockFileManager.EXPECT().Upload(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, f *os.File, _ ...string) (filemanager.UploadedFile, error) {
+				uploadFile = f
+				return filemanager.UploadedFile{}, errors.New("upload failed")
+			},
+		)
+
+		g := &GRPC{
+			conf: config.New(),
+			fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+				return mockFileManager, nil
+			},
+		}
+
+		err := g.validateObjectStorage(context.Background(), request)
+		require.Error(t, err)
+		requireFileClosed(t, uploadFile)
+	})
+}


### PR DESCRIPTION
## Description

Several upload/download helpers opened files and returned without closing them, leaking file descriptors under retry and error paths.

This is **not a duplicate** of stale #7106 / #7234 (those PRs went stale and the leaks are still in master). This PR covers those leftover batchrouter leaks **and** unique leaks that had no open PR, with tests.

### Leaks fixed

1. **`warehouse/api/grpc.go` `validateObjectStorage` (unique)**
   - Upload failure returned without `Close`.
   - The same `f` was reused for `os.CreateTemp`. A naive `defer f.Close()` after the first open is wrong: after reassignment it closes the last file twice and leaks the first.
   - Download failure returned without `Close`.
   - Fix: separate `uploadFile` / `downloadFile` variables, with `defer func() { _ = x.Close() }()` immediately after each successful open/create.

2. **Lytics `UploadBulkFile` (unique)**
   - `os.Open` then HTTP body, never closed.

3. **Eloqua `UploadData` (unique)**
   - Same pattern as Lytics.

4. **`router/batchrouter/handle.go` `upload()` (Closes #7071)**
   - `os.Open(gzipFilePath)` was never closed (stale #7106).
   - Open failure now returns an error instead of panicking.

5. **`router/batchrouter/handle_lifecycle.go` `crashRecover()`**
   - Download failure: `jsonFile` never closed and the temp file was left behind.
   - Success: `gzip.Reader.Close()` does **not** close the underlying `rawf`.
   - `defer os.Remove(jsonPath)` inside the loop stacked until function return.
   - Fix: close files on both paths, close `rawf` after the gzip reader, and `os.Remove` immediately after each journal entry.

## Linear Ticket

N/A — OSS fix for leftover file-descriptor leaks, including #7071.

## Test plan

- [x] `go test ./warehouse/api/ -count=1 -timeout 120s -run 'TestValidateObjectStorageClosesFiles'`
- [x] `go test ./router/batchrouter/ -count=1 -timeout 120s -run 'TestUploadClosesGzipFile|TestCrashRecoverClosesFiles'`
- [x] `go test ./router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/ -count=1 -timeout 120s -run 'TestUploadBulkFileSuccessAndError'`
- [x] `go test ./router/batchrouter/asyncdestinationmanager/eloqua/ -count=1 -timeout 120s -run 'TestUploadDataSuccessAndError'`

## CLA

First-time contributor: I will sign the CLA at https://forms.gle/845JRGVZaC6kPZy68

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.