### PR TITLE
fix(bigquery): preserve existing configured dataset

### DIFF
--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -893,7 +893,61 @@ func (bq *BigQuery) Setup(ctx context.Context, warehouse model.Warehouse, upload
 	bq.projectID = strings.TrimSpace(bq.warehouse.GetStringDestinationConfig(bq.conf, model.ProjectSetting))
 
 	bq.db, err = bq.connect(ctx)
-	return err
+	if err != nil {
+		return err
+	}
+
+	bq.namespace = bq.resolveNamespace(ctx, bq.datasetExists)
+	return nil
+}
+
+// resolveNamespace prefers the dataset the user configured verbatim over the
+// sanitised one, when the configured dataset actually exists in BigQuery.
+//
+// ToSafeNamespace snake-cases the namespace, which inserts an underscore at
+// every letter/digit boundary: a dataset configured as `analytics_euwe1`
+// becomes `analytics_euwe_1`. That silently points the destination at a dataset
+// that does not exist, and BigQuery reports the resulting INFORMATION_SCHEMA
+// read as a permission error, which is hard to trace back to the rename.
+//
+// Existing behaviour is unchanged whenever the configured dataset is absent:
+// the sanitised namespace is kept and created as before.
+func (bq *BigQuery) resolveNamespace(ctx context.Context, exists func(context.Context, string) (bool, error)) string {
+	configured := strings.TrimSpace(bq.warehouse.GetStringDestinationConfig(bq.conf, model.NamespaceSetting))
+	if configured == "" || configured == bq.namespace {
+		return bq.namespace
+	}
+
+	configuredExists, err := exists(ctx, configured)
+	if err != nil {
+		bq.logger.Warnn("Checking if configured dataset exists",
+			logger.NewStringField("configuredNamespace", configured),
+			obskit.Namespace(bq.namespace),
+			obskit.Error(err),
+		)
+		return bq.namespace
+	}
+	if !configuredExists {
+		return bq.namespace
+	}
+
+	bq.logger.Infon("Using configured dataset since it already exists",
+		logger.NewStringField("configuredNamespace", configured),
+		obskit.Namespace(bq.namespace),
+	)
+	return configured
+}
+
+func (bq *BigQuery) datasetExists(ctx context.Context, namespace string) (bool, error) {
+	_, err := bq.db.Dataset(namespace).Metadata(ctx)
+	if err != nil {
+		var e *googleapi.Error
+		if errors.As(err, &e) && e.Code == 404 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (*BigQuery) TestConnection(_ context.Context, _ model.Warehouse) (err error) {

--- a/warehouse/integrations/bigquery/namespace_test.go
+++ b/warehouse/integrations/bigquery/namespace_test.go
@@ -1,0 +1,107 @@
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+func TestResolveNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	// namespace as sanitised by warehouseutils.ToSafeNamespace, which snake-cases
+	// the configured value and so splits the letter/digit boundary in `euwe1`.
+	const (
+		configuredNamespace = "bq_events_zm_dev_dts_euwe1"
+		sanitisedNamespace  = "bq_events_zm_dev_dts_euwe_1"
+	)
+
+	newBQ := func(t *testing.T, destConfig map[string]any, namespace string) *BigQuery {
+		t.Helper()
+
+		bq := New(config.New(), logger.NOP)
+		bq.namespace = namespace
+		bq.warehouse = model.Warehouse{
+			Namespace:   namespace,
+			Destination: backendconfig.DestinationT{Config: destConfig},
+		}
+		return bq
+	}
+
+	existing := func(names ...string) func(context.Context, string) (bool, error) {
+		return func(_ context.Context, namespace string) (bool, error) {
+			for _, name := range names {
+				if name == namespace {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+	}
+
+	t.Run("keeps the configured dataset when it already exists", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{"namespace": configuredNamespace}, sanitisedNamespace)
+
+		require.Equal(t, configuredNamespace, bq.resolveNamespace(ctx, existing(configuredNamespace)))
+	})
+
+	t.Run("keeps the sanitised dataset when the configured one does not exist", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{"namespace": configuredNamespace}, sanitisedNamespace)
+
+		require.Equal(t, sanitisedNamespace, bq.resolveNamespace(ctx, existing()))
+	})
+
+	t.Run("prefers the configured dataset when both datasets exist", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{"namespace": configuredNamespace}, sanitisedNamespace)
+
+		resolved := bq.resolveNamespace(ctx, existing(configuredNamespace, sanitisedNamespace))
+		require.Equal(t, configuredNamespace, resolved)
+	})
+
+	t.Run("keeps the sanitised dataset when the existence check fails", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{"namespace": configuredNamespace}, sanitisedNamespace)
+
+		resolved := bq.resolveNamespace(ctx, func(context.Context, string) (bool, error) {
+			return false, errors.New("permission denied")
+		})
+		require.Equal(t, sanitisedNamespace, resolved)
+	})
+
+	t.Run("no existence check when sanitising did not change the namespace", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{"namespace": "bq_events"}, "bq_events")
+
+		called := false
+		resolved := bq.resolveNamespace(ctx, func(context.Context, string) (bool, error) {
+			called = true
+			return true, nil
+		})
+		require.Equal(t, "bq_events", resolved)
+		require.False(t, called, "existence check should be skipped")
+	})
+
+	t.Run("no existence check when no namespace is configured", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{}, sanitisedNamespace)
+
+		called := false
+		resolved := bq.resolveNamespace(ctx, func(context.Context, string) (bool, error) {
+			called = true
+			return true, nil
+		})
+		require.Equal(t, sanitisedNamespace, resolved)
+		require.False(t, called, "existence check should be skipped")
+	})
+
+	t.Run("whitespace only namespace is ignored", func(t *testing.T) {
+		bq := newBQ(t, map[string]any{"namespace": "   "}, sanitisedNamespace)
+
+		require.Equal(t, sanitisedNamespace, bq.resolveNamespace(ctx, existing("   ")))
+	})
+}

--- a/warehouse/internal/model/settings.go
+++ b/warehouse/internal/model/settings.go
@@ -26,6 +26,7 @@ var (
 	SSLModeSetting                     DestinationConfigSetting = destConfSetting("sslMode")
 	ProjectSetting                     DestinationConfigSetting = destConfSetting("project")
 	CredentialsSetting                 DestinationConfigSetting = destConfSetting("credentials")
+	NamespaceSetting                   DestinationConfigSetting = destConfSetting("namespace")
 	LocationSetting                    DestinationConfigSetting = destConfSetting("location")
 	CACertificateSetting               DestinationConfigSetting = destConfSetting("caCertificate")
 	ClusterSetting                     DestinationConfigSetting = destConfSetting("cluster")


### PR DESCRIPTION
# Description

Preserve an explicitly configured BigQuery dataset ID when that exact dataset already exists.

The warehouse namespace builder snake-cases custom namespaces before the BigQuery manager is created. `bq_events_zm_dev_dts_euwe1`, for example, becomes `bq_events_zm_dev_dts_euwe_1` due to its letter-to-digit boundary. The BigQuery setup path now checks the original configured dataset after establishing its client. If it exists, subsequent schema management and load operations use it verbatim. If it does not exist, the existing sanitised namespace behaviour remains unchanged.

Added regression coverage for the exact letter/digit case, absent datasets, both datasets existing, and failed/no-op checks.

## Linear Ticket

No linear provided, but I have filed a support ticket for a finding, this would solve that (I think)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

## New behavior

- Exact configured dataset exists: preserve its ID, including letter-to-digit boundaries.
- Exact configured dataset is absent: retain the existing sanitised name and creation flow.
- Dataset lookup errors: retain the existing sanitised name rather than failing a previously valid setup path.
